### PR TITLE
Revert "Remove Math dependency     Remove usage of random from Math in favor of built-in functions in Swift 4.2"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,15 +17,16 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/dn-m/Structure", .branch("swift-4.2")),
+        .package(url: "https://github.com/dn-m/Math", .branch("swift-4.2"))
     ],
     targets: [
 
         // Sources
         .target(name: "Articulations", dependencies: []),
         .target(name: "Dynamics", dependencies: ["Destructure", "Predicates"]),
-        .target(name: "Pitch", dependencies: ["StructureWrapping", "Combinatorics"]),
+        .target(name: "Pitch", dependencies: ["Math", "StructureWrapping", "Combinatorics"]),
         .target(name: "Rhythm", dependencies: ["MetricalDuration"]),
-        .target(name: "MetricalDuration", dependencies: ["DataStructures"]),
+        .target(name: "MetricalDuration", dependencies: ["Math", "DataStructures"]),
         .target(name: "Tempo", dependencies: ["Rhythm"]),
         .target(name: "Meter", dependencies: ["Rhythm", "Tempo"]),
         .target(name: "MusicModel", dependencies: [

--- a/Sources/Pitch/NoteNumber.swift
+++ b/Sources/Pitch/NoteNumber.swift
@@ -22,7 +22,7 @@ public struct NoteNumber: DoubleWrapping {
      - TODO: Implement `inRange: _` or similar.
      */
     public static func random(resolution: Double = 1) -> NoteNumber {
-        return NoteNumber(Double.random(in: 60 ..< 72))
+        return NoteNumber(Double.random(min: 60, max: 72))
     }
     
     // MARK: - Instance Properties

--- a/Tests/MeterTests/MeterCollectionTests.swift
+++ b/Tests/MeterTests/MeterCollectionTests.swift
@@ -18,8 +18,8 @@ class MeterCollectionTests: XCTestCase {
     var meters: Meter.Collection {
         let builder = Meter.Collection.Builder()
         (0..<500).forEach { _ in
-            let beats = Int.random(in: 3 ..< 9)
-            let subdivision = [16,8,4].randomElement()!
+            let beats = Int.random(min: 3, max: 9)
+            let subdivision = [16,8,4].random
             builder.add(.init(Meter(beats,subdivision)))
         }
         return builder.build()
@@ -419,5 +419,12 @@ class MeterCollectionTests: XCTestCase {
         XCTAssertEqual(fragments.count, 66)
         XCTAssertEqual(meters.base.count, flattenedFragments.count)
         zip(meters.base.map { $0.1 }, flattenedFragments).forEach { XCTAssertEqual($0,$1) }
+    }
+}
+
+extension Array {
+
+    var random: Element {
+        return self[Int.random(min: startIndex, max: endIndex - 1)]
     }
 }


### PR DESCRIPTION
Reverts dn-m/Music#18.

Actually, we need the `Math` in there for `ordered`, `Rational`, etc.