### PR TITLE
Don't inherently constraint Rhythm(Leaf).T: Equatable

### DIFF
--- a/Sources/MusicModel/Model.Builder.swift
+++ b/Sources/MusicModel/Model.Builder.swift
@@ -252,7 +252,7 @@ extension Model {
 }
 
 /// - TODO: Move to `dn-m/Rhythm`.
-extension Rhythm {
+extension Rhythm where T: Equatable {
     
     var events: [T] {
         return leaves.compactMap { leaf in

--- a/Sources/Rhythm/RhythmLeaf.swift
+++ b/Sources/Rhythm/RhythmLeaf.swift
@@ -9,7 +9,7 @@ import MetricalDuration
 
 /// - Note: At some point, nest this within `Rhythm`, inheriting `T`. Currently, this produces
 /// "Runtime Error: cyclic metadata dependency detected, aborting" (SR-4383).
-public struct RhythmLeaf <T: Equatable> {
+public struct RhythmLeaf <T> {
 
     public let metricalDuration: MetricalDuration
     public let context: MetricalContext<T>
@@ -38,9 +38,4 @@ extension RhythmLeaf {
     }
 }
 
-extension RhythmLeaf: Equatable {
-
-    public static func == (lhs: RhythmLeaf<T>, rhs: RhythmLeaf<T>) -> Bool {
-        return lhs.metricalDuration == rhs.metricalDuration && lhs.context == rhs.context
-    }
-}
+extension RhythmLeaf: Equatable where T: Equatable { }

--- a/Sources/Rhythm/RhythmTree.swift
+++ b/Sources/Rhythm/RhythmTree.swift
@@ -10,7 +10,7 @@ import Restructure
 import Math
 import MetricalDuration
 
-public struct Rhythm <T: Equatable> {
+public struct Rhythm <T> {
     public let metricalDurationTree: MetricalDurationTree
     public let leaves: [RhythmLeaf<T>]
 }


### PR DESCRIPTION
Given conditional `Equatable` conformance, the value contained by `Rhythm` values needn't be `Equatable` be default.