### PR TITLE
Update a few tail calls to become Arrays momentarily in bad code anyway

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/dn-m/Math",
         "state": {
           "branch": null,
-          "revision": "dc8703a15bac281f30d9ae2802d583b02c89f4ee",
-          "version": "0.1.3"
+          "revision": "cafcb08302f728712872fd9ccbe82bf274f69f13",
+          "version": "0.2.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/dn-m/PerformanceTesting",
         "state": {
           "branch": null,
-          "revision": "fc96795471fce16de0277ec0dbd0f69f5dd013d6",
-          "version": "0.1.0"
+          "revision": "b76715a574872e29fe24f70b45f14c7e1bccf170",
+          "version": "0.2.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
           "branch": null,
-          "revision": "95a3c7e50118006ae7d415dbe24d724936c3ad07",
-          "version": "0.3.1"
+          "revision": "0b2a60740e9718fc49ae39a907982c4ae60ca008",
+          "version": "0.5.1"
         }
       }
     ]

--- a/Sources/Dynamics/Dynamic+Validator.swift
+++ b/Sources/Dynamics/Dynamic+Validator.swift
@@ -22,9 +22,9 @@ extension Dynamic {
             
             switch head {
             case .niente:
-                return tail.isEmpty
+                return Array(tail).isEmpty
             case .mezzo:
-                return tail == [.forte] || tail == [.piano]
+                return Array(tail) == [.forte] || Array(tail) == [.piano]
             default:
                 return tail.isHomogeneous
             }

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -168,14 +168,14 @@ extension Tree where Branch == Int, Leaf == Int {
             case let value as Leaf:
 
                 // Input: `[T]`
-                if tail.isEmpty {
+                if Array(tail).isEmpty {
                     return .branch(value, branch.map(traverse))
                 }
 
                 // Input: `[T, [...]]`
                 guard
-                    tail.count == 1,
-                    let children = tail.first as? [Any]
+                    Array(tail).count == 1,
+                    let children = Array(tail).first as? [Any]
                 else {
                     fatalError("Ill-formed nested array")
                 }

--- a/Sources/Rhythm/RhythmTree.swift
+++ b/Sources/Rhythm/RhythmTree.swift
@@ -107,11 +107,11 @@ extension Rhythm.Leaf: Equatable where T: Equatable { }
 public func lengths <S,T> (of rhythms: S) -> [MetricalDuration]
     where S: Sequence, S.Element == Rhythm<T>
 {
-    func merge(
-        _ leaves: ArraySlice<Rhythm<T>.Leaf>,
+    func merge <S> (
+        _ leaves: S,
         into accum: [MetricalDuration],
         tied: MetricalDuration?
-    ) -> [MetricalDuration]
+    ) -> [MetricalDuration] where S: Sequence, S.Element == Rhythm<T>.Leaf
     {
         guard let (leaf, remaining) = leaves.destructured else { return accum + tied }
 


### PR DESCRIPTION
Update for `Structure` `0.5.1`, which updates `destructured` to operate over `Sequence` values.

The code updated here with `Array` inits are both unfortunate and should be removed / replaced anyway.