### PR TITLE
Remove Lisp-like ProportionTree initialization with [Any]

### DIFF
--- a/Sources/Rhythm/MetricalDurationTree.swift
+++ b/Sources/Rhythm/MetricalDurationTree.swift
@@ -80,14 +80,6 @@ public func * (_ subdivision: Int, proportions: [Int]) -> MetricalDurationTree {
     return MetricalDurationTree(subdivision, ProportionTree(subdivision,proportions))
 }
 
-/// - returns: A `MetricalDurationTree` with the given `metricalDuration` as the value of the
-/// root node, and the given `proportions` scaled appropriately.
-public func * (_ metricalDuration: MetricalDuration, _ proportions: [Any])
-    -> MetricalDurationTree
-{
-    return MetricalDurationTree(metricalDuration, ProportionTree(proportions))
-}
-
 /// - returns: A single-depth `MetricalDurationTree` with the given `metricalDuration` as the 
 /// value of the root node, and the given `proportions` mapped accordingly as the children.
 ///

--- a/Sources/Rhythm/MetricalDurationTree.swift
+++ b/Sources/Rhythm/MetricalDurationTree.swift
@@ -102,6 +102,6 @@ public func * (_ metricalDuration: MetricalDuration, _ proportions: [Int])
     }
 
     let beats = metricalDuration.numerator
-    let proportionTree = ProportionTree([beats, proportions])
+    let proportionTree = ProportionTree(beats, proportions)
     return MetricalDurationTree(metricalDuration, proportionTree)
 }

--- a/Sources/Rhythm/MetricalDurationTree.swift
+++ b/Sources/Rhythm/MetricalDurationTree.swift
@@ -76,8 +76,8 @@ extension Tree where Branch == MetricalDuration, Leaf == MetricalDuration {
 }
 
 /// - returns: A `MetricalDurationTree` with the given `subdivision` applied to each node.
-public func * (_ subdivision: Int, proportions: [Any]) -> MetricalDurationTree {
-    return MetricalDurationTree(subdivision, ProportionTree(proportions))
+public func * (_ subdivision: Int, proportions: [Int]) -> MetricalDurationTree {
+    return MetricalDurationTree(subdivision, ProportionTree(subdivision,proportions))
 }
 
 /// - returns: A `MetricalDurationTree` with the given `metricalDuration` as the value of the

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -12,7 +12,7 @@ import DataStructures
 import Math
 
 /// Similar to the proportional aspect of the `OpenMusic` `Rhythm Tree` structure.
-public typealias ProportionTree = Tree<Int, Int>
+public typealias ProportionTree = Tree<Int,Int>
 
 extension Tree where Branch == Int, Leaf == Int {
 

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -171,11 +171,8 @@ extension Tree where Branch == Int, Leaf == Int {
         /// along between levels.
         ///
         /// - note: Need to make inherited optional? // this smells
-        func propagatedDown(
-            _ original: DistanceTree,
-            _ propagatedUp: DistanceTree,
-            inherited: Int?
-        ) -> DistanceTree
+        func propagatedDown(_ original: DistanceTree, _ propagatedUp: DistanceTree, inherited: Int?)
+            -> DistanceTree
         {
 
             switch (original, propagatedUp) {

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -32,33 +32,14 @@ extension Tree where Branch == Int, Leaf == Int {
         return traverse(self, accum: 1)
     }
     
-    /// - returns: A new `ProportionTree` in which the value of each node can be represented
+    /// - Returns: A new `ProportionTree` in which the value of each node can be represented
     /// with the same subdivision-level (denominator).
     public var normalized: ProportionTree {
-
-        // Pre-processing
-
-        // Reduce each level of children by their `gcd`
         let siblingsReduced = reducingSiblings
-
-        // Match parent values to the closest power-of-two to the sum of their children values.
         let parentsMatched = siblingsReduced.matchingParentsToChildren
-
-        // Generate a tree which contains the values necessary to multiply each node of a
-        // `reduced` tree to properly match the values in a `parentsMatched` tree.
         let distances = zip(siblingsReduced, parentsMatched, encodeDistance).propagated
-
-        // Processing
-
-        /// Multiply each value in `siblingsReduced` by the corrosponding multiplier in the
-        /// `ProportionTree`.
         let updatedTree = zip(siblingsReduced, distances, decodeDuration)
-
-        // Post-processing
-
-        /// Ensure there are no leaves dangling unmatched to their parents.
         let childrenMatched = updatedTree.matchingChildrenToParents
-
         return childrenMatched
     }
     

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -16,9 +16,8 @@ public typealias ProportionTree = Tree<Int, Int>
 
 extension Tree where Branch == Int, Leaf == Int {
 
-    /// - returns: `Tree` containing the inherited scale of each node contained herein.
+    /// - Returns: `Tree` containing the inherited scale of each node contained herein.
     public var scaling: Tree<Fraction, Fraction> {
-
         func traverse(_ tree: ProportionTree, accum: Fraction) -> Tree<Fraction, Fraction> {
             switch tree {
             case .leaf:
@@ -68,13 +67,11 @@ extension Tree where Branch == Int, Leaf == Int {
     ///
     /// - note: In the case of parents with a single child, no reduction occurs.
     internal var reducingSiblings: ProportionTree {
-
         func reduced(_ trees: [ProportionTree]) -> [ProportionTree] {
             let values = trees.map { $0.value }
             let reduced = values.map { $0 / values.gcd }
             return zip(trees, reduced).map { $0.updating(value: $1) }
         }
-
         guard case .branch(let value, let trees) = self, trees.count > 1 else { return self }
         return .branch(value, reduced(trees).map { $0.reducingSiblings } )
     }
@@ -87,14 +84,12 @@ extension Tree where Branch == Int, Leaf == Int {
     /// - Parent is required scaled _up_ to match the sum of its children
     /// - Parent is required scaled _down_ to match the sum of its children
     internal var matchingParentsToChildren: ProportionTree {
-
         func updateDuration(_ original: Int, _ children: [ProportionTree]) -> Int {
             let relativeDurations = children.map { $0.value }
             let sum = relativeDurations.sum
             let coefficient = original >> countTrailingZeros(original)
             return closestPowerOfTwo(coefficient: coefficient, to: sum)!
         }
-
         guard case .branch(let duration, let trees) = self else { return self }
         let newDuration = updateDuration(duration, trees)
         return .branch(newDuration, trees.map { $0.matchingParentsToChildren })
@@ -156,11 +151,7 @@ extension Tree where Branch == Int, Leaf == Int {
 
         /// Propagate up and accumulate the maximum of the sums of children values
         func propagatedUp(_ tree: DistanceTree) -> DistanceTree {
-            
-            guard case .branch(let value, let trees) = tree else {
-                return tree
-            }
-
+            guard case .branch(let value, let trees) = tree else { return tree }
             let newTrees = trees.map(propagatedUp)
             let max = newTrees.map { $0.value }.max()!
             return .branch(value + max, newTrees)
@@ -174,28 +165,21 @@ extension Tree where Branch == Int, Leaf == Int {
         func propagatedDown(_ original: DistanceTree, _ propagatedUp: DistanceTree, inherited: Int?)
             -> DistanceTree
         {
-
             switch (original, propagatedUp) {
-
             // If we are leaf,
             case (.leaf, .leaf):
                 return .leaf(inherited!)
-
             // Replace value with inherited (if present), or already propagated
             case (.branch(let original, let oTrees), .branch(let propagated, let pTrees)):
-
                 let value = inherited ?? propagated
                 let subTrees = zip(oTrees, pTrees).map { o, p in
                     propagatedDown(o, p, inherited: value - original)
                 }
-
                 return .branch(value, subTrees)
-
             // Enforce same-shaped trees
             default:
                 fatalError("Incompatible trees")
             }
-
             return propagatedUp
         }
 

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -171,7 +171,7 @@ extension Tree where Branch == Int, Leaf == Int {
         /// along between levels.
         ///
         /// - note: Need to make inherited optional? // this smells
-        func propagateDown(
+        func propagatedDown(
             _ original: DistanceTree,
             _ propagatedUp: DistanceTree,
             inherited: Int?
@@ -189,7 +189,7 @@ extension Tree where Branch == Int, Leaf == Int {
 
                 let value = inherited ?? propagated
                 let subTrees = zip(oTrees, pTrees).map { o, p in
-                    propagateDown(o, p, inherited: value - original)
+                    propagatedDown(o, p, inherited: value - original)
                 }
 
                 return .branch(value, subTrees)
@@ -202,7 +202,6 @@ extension Tree where Branch == Int, Leaf == Int {
             return propagatedUp
         }
 
-        let propagatedUp = propagatedUp(self)
-        return propagateDown(self, propagatedUp, inherited: nil)
+        return propagatedDown(self, propagatedUp(self), inherited: nil)
     }
 }

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -132,6 +132,11 @@ extension Tree where Branch == Int, Leaf == Int {
 
 extension Tree where Branch == Int, Leaf == Int {
 
+    /// Create a single-depth `ProportionTree` with the given root `duration` and child `durations`.
+    public init(_ duration: Int, _ durations: [Int]) {
+        self = Tree.branch(duration, durations.map(Tree.leaf)).normalized
+    }
+
     /// Create an arbitrarily-nested `ProportionTree` with an array.
     ///
     /// Modeled after OpenMusic's `RhythmTree` notation.

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -155,13 +155,13 @@ extension Tree where Branch == Int, Leaf == Int {
     fileprivate var propagated: DistanceTree {
 
         /// Propagate up and accumulate the maximum of the sums of children values
-        func propagateUp(_ tree: DistanceTree) -> DistanceTree {
+        func propagatedUp(_ tree: DistanceTree) -> DistanceTree {
             
             guard case .branch(let value, let trees) = tree else {
                 return tree
             }
 
-            let newTrees = trees.map(propagateUp)
+            let newTrees = trees.map(propagatedUp)
             let max = newTrees.map { $0.value }.max()!
             return .branch(value + max, newTrees)
         }
@@ -202,7 +202,7 @@ extension Tree where Branch == Int, Leaf == Int {
             return propagatedUp
         }
 
-        let propagatedUp = propagateUp(self)
+        let propagatedUp = propagatedUp(self)
         return propagateDown(self, propagatedUp, inherited: nil)
     }
 }

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -200,6 +200,11 @@ extension Tree where Branch == Int, Leaf == Int {
     }
 }
 
+/// Create a single-depth `ProportionTree` with the given root `duration` and child `durations`.
+public func * (duration: Int, durations: [Int]) -> ProportionTree {
+    return ProportionTree(duration,durations)
+}
+
 /// Tree recording the change (in degree of power-of-two) needed to normalize a 
 /// `ProprtionTree`.
 private typealias DistanceTree = Tree<Int,Int>

--- a/Sources/Rhythm/ProportionTree.swift
+++ b/Sources/Rhythm/ProportionTree.swift
@@ -136,73 +136,11 @@ extension Tree where Branch == Int, Leaf == Int {
     public init(_ duration: Int, _ durations: [Int]) {
         self = Tree.branch(duration, durations.map(Tree.leaf)).normalized
     }
-
-    /// Create an arbitrarily-nested `ProportionTree` with an array.
-    ///
-    /// Modeled after OpenMusic's `RhythmTree` notation.
-    ///
-    /// A single-depth tree looks like this:
-    ///
-    ///     let singleDepth = [1, [1,2,3]]
-    ///
-    /// A multi-depth tree looks like this:
-    ///
-    ///     let multiDepth = [1, [1,[2,[1,2,[3,[1,2,3]]]],3]]
-    ///
-    /// Good luck.
-    public init(_ value: [Any]) {
-
-        func traverse(_ value: Any) -> ProportionTree {
-
-            // Input: `T`
-            if let leaf = value as? Leaf {
-                return .leaf(leaf)
-            }
-
-            // Input: `[Any]`
-            guard
-                let branch = value as? [Any],
-                let (head, tail) = branch.destructured
-            else {
-                fatalError("Ill-formed nested array")
-            }
-
-            switch head {
-
-            // Input: `[T, ...]`
-            case let value as Leaf:
-
-                // Input: `[T]`
-                if Array(tail).isEmpty {
-                    return .branch(value, branch.map(traverse))
-                }
-
-                // Input: `[T, [...]]`
-                guard
-                    Array(tail).count == 1,
-                    let children = Array(tail).first as? [Any]
-                else {
-                    fatalError("Ill-formed nested array")
-                }
-
-                return .branch(value, children.map(traverse))
-
-            // Input: `[[T ... ], ... ]`
-            case let branch as [Any]:
-                return traverse(branch)
-
-            default:
-                fatalError("Ill-formed nested array")
-            }
-        }
-
-        self = traverse(value).normalized
-    }
 }
 
 /// Create a single-depth `ProportionTree` with the given root `duration` and child `durations`.
 public func * (duration: Int, durations: [Int]) -> ProportionTree {
-    return ProportionTree(duration,durations)
+    return ProportionTree.init(duration,durations)
 }
 
 /// Tree recording the change (in degree of power-of-two) needed to normalize a 

--- a/Tests/RhythmTests/MetricalDurationTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTests.swift
@@ -1,8 +1,0 @@
-//
-//  MetricalDurationTests.swift
-//  Rhythm
-//
-//  Created by James Bean on 1/28/17.
-//
-//
-

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -148,10 +148,4 @@ class MetricalDurationTreeTests: XCTestCase {
         let tree = 1/>8 * [1,1,1]
         XCTAssertEqual(tree.offsets, [Fraction(0,1), Fraction(1,24), Fraction(1,12)])
     }
-
-    func testScaled() {
-        let tree = 4/>4 * [1,[1,[2,[1,1,1]],1,1]]
-        let scaled = tree.scaled
-        print(scaled)
-    }
 }

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -15,17 +15,13 @@ import Rhythm
 class MetricalDurationTreeTests: XCTestCase {
 
     func testInitSubdivisionAndProportionTree() {
-
-        let proportionTree = ProportionTree(1, [1,2,3])
-        let result = MetricalDurationTree(16, proportionTree)
-
+        let result = MetricalDurationTree(16, ProportionTree(1, [1,2,3]))
         let expected = MetricalDurationTree.branch(4/>16, [
             .leaf(1/>16),
             .leaf(2/>16),
             .leaf(3/>16)
         ])
-
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testInitSubdivisionOperator() {

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -54,16 +54,13 @@ class MetricalDurationTreeTests: XCTestCase {
     }
 
     func testInitMetricalDurationProportionTreeOperator() {
-
-        let result = 17/>64 * [1,[1,2,3]]
-
+        let result = MetricalDurationTree(17/>64, ProportionTree(1,[1,2,3]))
         let expected = MetricalDurationTree.branch(17/>64, [
             .leaf(2/>64),
             .leaf(4/>64),
             .leaf(6/>64)
         ])
-
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testInitEmptyArray() {

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -64,7 +64,6 @@ class MetricalDurationTreeTests: XCTestCase {
     }
 
     func testInitEmptyArray() {
-
         let tree = 3/>16 * []
 
         guard case .branch(let duration, let trees) = tree else {

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -25,16 +25,14 @@ class MetricalDurationTreeTests: XCTestCase {
     }
 
     func testInitSubdivisionOperator() {
-
-        let result = 16 * [[1,[1,2,3]]]
-
+        let result = MetricalDurationTree(16, ProportionTree(1,[1,2,3]))
         let expected = MetricalDurationTree.branch(4/>16, [
             .leaf(1/>16),
             .leaf(2/>16),
             .leaf(3/>16)
         ])
 
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testInitMetricalDuration() {

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -36,10 +36,12 @@ class MetricalDurationTreeTests: XCTestCase {
     }
 
     func testInitMetricalDuration() {
-
-        let proportionTree = ProportionTree([1,[[1,[1,1,1]],2,3]])
+        let proportionTree: ProportionTree = .branch(1, [
+            .branch(1, [.leaf(1), .leaf(1), .leaf(1)]),
+            .leaf(2),
+            .leaf(3)
+        ])
         let result = MetricalDurationTree(5/>32, proportionTree)
-
         let expected = MetricalDurationTree.branch(10/>64, [
             .branch(2/>64, [
                 .leaf(1/>64),
@@ -50,7 +52,7 @@ class MetricalDurationTreeTests: XCTestCase {
             .leaf(6/>64)
         ])
 
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testInitMetricalDurationProportionTreeOperator() {

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -58,20 +58,7 @@ class MetricalDurationTreeTests: XCTestCase {
 
         XCTAssert(result == expected)
     }
-
-    func testInitMetricalDurationProportionTreeOperator() {
-
-        let result = 17/>64 * [1,[1,2,3]]
-
-        let expected = MetricalDurationTree.branch(17/>64, [
-            .leaf(2/>64),
-            .leaf(4/>64),
-            .leaf(6/>64)
-        ])
-
-        XCTAssert(result == expected)
-    }
-
+    
     func testInitEmptyArray() {
 
         let tree = 3/>16 * []

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -16,7 +16,7 @@ class MetricalDurationTreeTests: XCTestCase {
 
     func testInitSubdivisionAndProportionTree() {
 
-        let proportionTree = ProportionTree([1,[1,2,3]])
+        let proportionTree = ProportionTree(1, [1,2,3])
         let result = MetricalDurationTree(16, proportionTree)
 
         let expected = MetricalDurationTree.branch(4/>16, [
@@ -58,7 +58,20 @@ class MetricalDurationTreeTests: XCTestCase {
 
         XCTAssert(result == expected)
     }
-    
+
+    func testInitMetricalDurationProportionTreeOperator() {
+
+        let result = 17/>64 * [1,[1,2,3]]
+
+        let expected = MetricalDurationTree.branch(17/>64, [
+            .leaf(2/>64),
+            .leaf(4/>64),
+            .leaf(6/>64)
+        ])
+
+        XCTAssert(result == expected)
+    }
+
     func testInitEmptyArray() {
 
         let tree = 3/>16 * []

--- a/Tests/RhythmTests/MetricalDurationTreeTests.swift
+++ b/Tests/RhythmTests/MetricalDurationTreeTests.swift
@@ -31,7 +31,6 @@ class MetricalDurationTreeTests: XCTestCase {
             .leaf(2/>16),
             .leaf(3/>16)
         ])
-
         XCTAssertEqual(result, expected)
     }
 
@@ -51,7 +50,6 @@ class MetricalDurationTreeTests: XCTestCase {
             .leaf(4/>64),
             .leaf(6/>64)
         ])
-
         XCTAssertEqual(result, expected)
     }
 

--- a/Tests/RhythmTests/ProportionTreeTests.swift
+++ b/Tests/RhythmTests/ProportionTreeTests.swift
@@ -277,7 +277,7 @@ class ProportionTreeTests: XCTestCase {
 
     func testScaleSimple() {
 
-        let tree = ProportionTree([1,[1,1,1]])
+        let tree = ProportionTree(1,[1,1,1])
 
         let value = Fraction(2,3)
         let expected = Tree<Fraction,Fraction>.branch(1, [

--- a/Tests/RhythmTests/ProportionTreeTests.swift
+++ b/Tests/RhythmTests/ProportionTreeTests.swift
@@ -14,7 +14,6 @@ import Math
 class ProportionTreeTests: XCTestCase {
 
     var veryNested: Tree<Int,Int> {
-
         return Tree.branch(1, [
             .branch(2, [
                 .branch(16, [
@@ -52,18 +51,15 @@ class ProportionTreeTests: XCTestCase {
     }
 
     func testReducedSingleDepth() {
-
         let tree = Tree.branch(1, [
             .leaf(2),
             .leaf(4),
             .leaf(6)
         ])
-
         XCTAssertEqual(tree.reducingSiblings.leaves, [1,2,3])
     }
 
     func testReducedNested() {
-
         let tree = Tree.branch(1, [
             .leaf(2),
             .branch(4, [
@@ -73,14 +69,11 @@ class ProportionTreeTests: XCTestCase {
             ]),
             .leaf(8)
         ])
-
         XCTAssertEqual(tree.reducingSiblings.leaves, [1,3,1,2,4])
     }
 
     func testReducedVeryNested() {
-
         let result = veryNested.reducingSiblings
-
         let expected = Tree.branch(1, [
             .branch(2, [
                 .branch(2, [
@@ -111,36 +104,22 @@ class ProportionTreeTests: XCTestCase {
                 ])
             ])
         ])
-
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testmatchingParentsToChildrenSingleDepthDownTwo() {
-
-        let tree = Tree.branch(6, [
-            .leaf(1),
-            .leaf(1)
-        ])
-
+        let tree = Tree.branch(6, [.leaf(1), .leaf(1)])
         XCTAssertEqual(tree.matchingParentsToChildren.value, 3)
     }
 
 	func testmatchingParentsToChildrenSingleDepthDownThree() {
-
-		let tree = Tree.branch(6, [
-			.leaf(1),
-			.leaf(2)
-			])
-
+		let tree = Tree.branch(6, [.leaf(1),.leaf(2)])
 		XCTAssertEqual(tree.matchingParentsToChildren.value, 3)
 	}
 
     func testmatchingParentsToChildrenSingleDepthUp() {
 
-        let tree = Tree.branch(1, [
-            .leaf(8),
-            .leaf(3)
-        ])
+        let tree = Tree.branch(1, [.leaf(8),.leaf(3)])
 
         XCTAssertEqual(tree.matchingParentsToChildren.value, 8)
     }

--- a/Tests/RhythmTests/ProportionTreeTests.swift
+++ b/Tests/RhythmTests/ProportionTreeTests.swift
@@ -118,16 +118,12 @@ class ProportionTreeTests: XCTestCase {
 	}
 
     func testmatchingParentsToChildrenSingleDepthUp() {
-
         let tree = Tree.branch(1, [.leaf(8),.leaf(3)])
-
         XCTAssertEqual(tree.matchingParentsToChildren.value, 8)
     }
 
     func testMatchParentsVeryNestedMultipleCases() {
-
         let result = veryNested.reducingSiblings.matchingParentsToChildren
-
         let expected = Tree.branch(8, [
             .branch(4, [
                 .branch(2, [
@@ -158,12 +154,10 @@ class ProportionTreeTests: XCTestCase {
                 ])
             ])
         ])
-
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testNormalizeVeryNested() {
-
         let expected = Tree.branch(512, [
             .branch(128, [
                 .branch(64, [
@@ -194,13 +188,11 @@ class ProportionTreeTests: XCTestCase {
                 ])
             ])
         ])
-
         let result = veryNested.normalized
-        XCTAssert(result == expected)
+        XCTAssertEqual(result, expected)
     }
 
     func testNormalizedNested() {
-
         let tree = Tree.branch(1, [
             .branch(2, [
                 .leaf(3),
@@ -216,7 +208,6 @@ class ProportionTreeTests: XCTestCase {
                 .leaf(1)
             ])
         ])
-
         let expected = Tree.branch(32, [
             .branch(8, [
                 .leaf(6),
@@ -232,39 +223,28 @@ class ProportionTreeTests: XCTestCase {
                 .leaf(2)
             ])
         ])
-
-        XCTAssert(tree.normalized == expected)
+        XCTAssertEqual(tree.normalized, expected)
     }
 
     func testNormalizeSingleDepth() {
-
-        let tree = Tree.branch(5, [
-            .leaf(1),
-            .leaf(1)
-        ])
-
+        let tree = Tree.branch(5, [.leaf(1), .leaf(1)])
         XCTAssertEqual(tree.normalized.leaves, [2,2])
     }
 
     func testNormalizeSingleDepthBranchOfSingleLeafOf3() {
-
         let tree = Tree.branch(3, [.leaf(3)])
         let normalizedTree = tree.normalized
-
-        XCTAssert(tree == normalizedTree)
+        XCTAssertEqual(tree, normalizedTree)
     }
 
     func testScaleSimple() {
-
         let tree = ProportionTree(1,[1,1,1])
-
         let value = Fraction(2,3)
         let expected = Tree<Fraction,Fraction>.branch(1, [
             .leaf(value),
             .leaf(value),
             .leaf(value)
         ])
-
-        XCTAssert(tree.scaling == expected)
+        XCTAssertEqual(tree.scaling, expected)
     }
 }

--- a/Tests/RhythmTests/RhythmTreeTests.swift
+++ b/Tests/RhythmTests/RhythmTreeTests.swift
@@ -14,15 +14,12 @@ import Rhythm
 class RhythmTreeTests: XCTestCase {
 
     func testInit() {
-
         let metricalDurationTree = 1/>8 * [1,2,3]
-
         let contexts: [MetricalContext<Int>] = [
             .instance(.event(1)),
             .continuation,
             .instance(.absence)
         ]
-
         _ = metricalDurationTree * contexts
     }
 }


### PR DESCRIPTION
The initializer for `ProportionTree` which took merely an `[Any]` was introduced to make it easier to test nested rhythmic structures quickly. It wasn't really worth it, though: concision and clarity at the call-site  can be achieved without dipping into the _very_ weakly-typed world.