### PR TITLE
Use the generalized lengths <S,T> to avoid creating an ArraySlice

### DIFF
--- a/Sources/Rhythm/RhythmTree.swift
+++ b/Sources/Rhythm/RhythmTree.swift
@@ -137,7 +137,7 @@ public func lengths <S,T> (of rhythms: S) -> [MetricalDuration]
         }
     }
 
-    return merge(ArraySlice(rhythms.flatMap { $0.leaves }), into: [], tied: nil)
+    return merge(rhythms.flatMap { $0.leaves }, into: [], tied: nil)
 }
 
 /// - returns: `RhythmTree` with the given `MetricalDurationTree` and `MetricalContext` values.


### PR DESCRIPTION
This PR removes a dangling use of `ArraySlice`, which was a product of a somewhat misguided performance optimization. Now that `lengths` is generic over any sequence, we don't need to create an `ArraySlice` here.