### PR TITLE
Implement Meter with power of two with any coefficient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9.4
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-10-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-28-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-15-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-07-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-01-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-01-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-01-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-15-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-07-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-10-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9.4
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-05-16-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-05-30-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode9
+osx_image: xcode9.4
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-05-30-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-01
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9.4
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-07-28-a
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-05-16-a
 script:
   - swift package update
   - swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ osx_image: xcode9
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-01
+  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-08-01-a
 script:
   - swift package update
   - swift test

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -34,7 +34,7 @@ public struct Meter: Rational {
     }
 }
 
-extension FixedWidthInteger {
+extension Subdivision {
     var isPowerOfTwoWithAnyCoefficient: Bool {
         if isPowerOfTwo { return true }
         return (1...self).lazy

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -27,22 +27,20 @@ public struct Meter: Rational {
     // MARK: Initializers
 
     /// Creates a `Meter` with the given `numerator` and `denominator`.
-    #warning("TODO: Allow non-2-coefficient powers-of-two for Meter.denominator")
     public init(_ numerator: Beats, _ denominator: Subdivision) {
-        print("denominator: \(denominator)")
-        var found = false
-        for coefficient in 1...denominator {
-            let powers = PowerSequence(coefficient: coefficient, max: denominator, doOvershoot: true)
-            print("powers: \(powers.map { $0 })")
-            if powers.contains(denominator) {
-                found = true
-                print("found!")
-                break
-            }
-        }
-        assert(found)
+        assert(denominator.isPowerOfTwoWithAnyCoefficient)
         self.numerator = numerator
         self.denominator = denominator
+    }
+}
+
+extension FixedWidthInteger {
+    var isPowerOfTwoWithAnyCoefficient: Bool {
+        guard !isPowerOfTwo else { return true }
+        return (1...self).lazy
+            .filter { $0.isOdd }
+            .flatMap { PowerSequence(coefficient: $0, max: self, doOvershoot: true) }
+            .contains(self)
     }
 }
 

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -29,7 +29,18 @@ public struct Meter: Rational {
     /// Creates a `Meter` with the given `numerator` and `denominator`.
     #warning("TODO: Allow non-2-coefficient powers-of-two for Meter.denominator")
     public init(_ numerator: Beats, _ denominator: Subdivision) {
-        assert(denominator.isPowerOfTwo, "Cannot create Meter with a non power-of-two denominator")
+        print("denominator: \(denominator)")
+        var found = false
+        for coefficient in 1...denominator {
+            let powers = PowerSequence(coefficient: coefficient, max: denominator, doOvershoot: true)
+            print("powers: \(powers.map { $0 })")
+            if powers.contains(denominator) {
+                found = true
+                print("found!")
+                break
+            }
+        }
+        assert(found)
         self.numerator = numerator
         self.denominator = denominator
     }

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -36,7 +36,7 @@ public struct Meter: Rational {
 
 extension FixedWidthInteger {
     var isPowerOfTwoWithAnyCoefficient: Bool {
-        guard !isPowerOfTwo else { return true }
+        if isPowerOfTwo { return true }
         return (1...self).lazy
             .filter { $0.isOdd }
             .flatMap { PowerSequence(coefficient: $0, max: self, doOvershoot: true) }

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -28,7 +28,7 @@ public struct Meter: Rational {
 
     /// Creates a `Meter` with the given `numerator` and `denominator`.
     public init(_ numerator: Beats, _ denominator: Subdivision) {
-        assert(denominator.isPowerOfTwoWithAnyCoefficient)
+        precondition(denominator.isPowerOfTwoWithAnyCoefficient)
         self.numerator = numerator
         self.denominator = denominator
     }

--- a/Tests/DurationTests/MeterTests.swift
+++ b/Tests/DurationTests/MeterTests.swift
@@ -1,0 +1,26 @@
+//
+//  MeterTests.swift
+//  DurationTests
+//
+//  Created by James Bean on 8/14/18.
+//
+
+import XCTest
+import Duration
+
+class MeterTests: XCTestCase {
+
+    func testNormalMeter() {
+        let _ = Meter(4,4)
+        let _ = Meter(3,8)
+        let _ = Meter(17,32)
+    }
+
+    func testIrrationalMeter() {
+        let _ = Meter(5,3)
+        let _ = Meter(5,6)
+        let _ = Meter(5,28)
+        let _ = Meter(17,56)
+        let _ = Meter(1,18)
+    }
+}

--- a/Tests/DurationTests/MeterTests.swift
+++ b/Tests/DurationTests/MeterTests.swift
@@ -17,6 +17,7 @@ class MeterTests: XCTestCase {
     }
 
     func testIrrationalMeter() {
+        let _ = Meter(4,1)
         let _ = Meter(5,3)
         let _ = Meter(5,6)
         let _ = Meter(5,28)


### PR DESCRIPTION
The so-and-incorrectly-named "irrational meters" of _the complexists_ demand meters with denominators which are a power-of-two, but with any coefficient (e.g., `3`, `6`, `12`, `14`, `18`, `56`, etc.).

This PR relaxes the `precondition` from requiring the denominator of a potential `Meter` be `.powerOfTwo` to being `.powerOfTwoWithAnyCoefficient`.