### PR TITLE
Inject Easing specification into Tempo.Interpolation.Collection.Builder

### DIFF
--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -88,12 +88,12 @@ extension Meter {
 
         // MARK: - Instance Properties
 
-        public let base: SortedDictionary<Fraction,Meter.Fragment>
+        public let base: SortedDictionary<Metric,Meter.Fragment>
 
         // MARK: - Initializers
 
         /// Create a `Meter.Collection` with the given `base`.
-        public init(_ base: SortedDictionary<Fraction, Meter.Fragment>) {
+        public init(_ base: SortedDictionary<Metric, Meter.Fragment>) {
             self.base = base
         }
 

--- a/Sources/Duration/Spanning/SpanningContainer.swift
+++ b/Sources/Duration/Spanning/SpanningContainer.swift
@@ -13,6 +13,7 @@ import DataStructures
 import Math
 
 /// Interface for values that contain a sequence of `SpanningFragment` type values.
+#warning("Rename SpanningContainer to IntervalCollection")
 public protocol SpanningContainer: RandomAccessCollectionWrapping, Spanning, Fragmentable
     where Metric == Spanner.Metric
 {
@@ -44,6 +45,11 @@ extension SpanningContainer {
     /// - Returns: An array of spanners in the given `range` of indices.
     public subscript(range: CountableClosedRange<Int>) -> [Spanner] {
         return range.map { base.values[$0] }
+    }
+
+    /// - Returns: A collection of the offsets of each spanner contained herein.
+    public var offsets: AnyCollection<Metric> {
+        return AnyCollection(base.keys)
     }
 
     /// Length of `SpanningContainer`.

--- a/Sources/Duration/Spanning/SpanningContainer.swift
+++ b/Sources/Duration/Spanning/SpanningContainer.swift
@@ -52,6 +52,11 @@ extension SpanningContainer {
         return AnyCollection(base.keys)
     }
 
+    /// - Returns: A collection of the spanners contained herein.
+    public var spanners: AnyCollection<Spanner> {
+        return AnyCollection(base.values)
+    }
+
     /// Length of `SpanningContainer`.
     public var length: Metric {
         return base.values.map { $0.length }.sum

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -12,8 +12,10 @@
     import Darwin.C
 #endif
 
+import DataStructures
+
 /// Model of a `Tempo`.
-public struct Tempo: Equatable {
+public struct Tempo {
 
     // MARK: - Associated Types
     
@@ -79,13 +81,15 @@ extension Tempo {
     }
 }
 
+extension Tempo: Equatable { }
+
 // FIXME: Move to own file (Tempo.Interpolation) when Swift compiler build-order bug resolved.
 import Math
 
 extension Tempo {
 
     /// Interpolation between two `Tempo` values.
-    public struct Interpolation: Equatable, DurationSpanning {
+    public struct Interpolation: DurationSpanning {
 
         // MARK: - Cases
 
@@ -227,6 +231,8 @@ extension Tempo {
     }
 }
 
+extension Tempo.Interpolation: Equatable { }
+
 extension Tempo.Interpolation: Fragmentable {
 
     // MARK: - Fragmentable
@@ -305,6 +311,8 @@ extension Tempo.Interpolation.Fragment {
     }
 }
 
+extension Tempo.Interpolation.Fragment: Equatable { }
+
 // FIXME: Move to own file (Tempo.Interpolation.Easing)
 import DataStructures
 
@@ -313,7 +321,7 @@ extension Tempo.Interpolation {
     /// Easing of `Interpolation`.
     //
     // TODO: Generalize this beyond tempi.
-    public enum Easing: Equatable {
+    public enum Easing {
 
         /// Linear interpolation.
         case linear
@@ -396,6 +404,8 @@ extension Tempo.Interpolation {
     }
 }
 
+extension Tempo.Interpolation.Easing: Equatable { }
+
 // FIXME: Move to own file (Tempo.Interpolation.Collection)
 public extension Tempo.Interpolation {
 
@@ -463,6 +473,8 @@ public extension Tempo.Interpolation {
         }
     }
 }
+
+extension Tempo.Interpolation.Collection: Equatable { }
 
 // FIXME: Move to own file (Tempo.Interpolation.Collection.Builder)
 

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -76,7 +76,6 @@ extension Tempo {
     /// - Returns: Duration in seconds for a beat at the given `subdivision`.
     public func duration(forBeatAt subdivision: Subdivision) -> Double {
         precondition(subdivision.isPowerOfTwo, "Subdivision must be a power-of-two")
-        #warning("FIXME: Assert that subdivision is within bounds")
         let quotient = Double(subdivision) / Double(self.subdivision)
         return durationOfBeat / quotient
     }

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -479,7 +479,7 @@ extension Tempo.Interpolation.Collection {
 
         // MARK: - Instance Properties
 
-        private var last: (Fraction, Tempo, Bool)?
+        private var last: (Fraction, Tempo, Tempo.Interpolation.Easing?)?
 
         /// The stateful, accumulating `offset` which becomes the metrical offset of a
         ///`Tempo.Interpolation.Fragment` value.
@@ -509,7 +509,7 @@ extension Tempo.Interpolation.Collection {
             -> Builder
         {
             self.intermediate.insert(fragment, key: offset)
-            last = (offset, fragment.base.end, true)
+            last = (offset, fragment.base.end, nil)
             offset += fragment.range.length
             return self
         }
@@ -522,7 +522,7 @@ extension Tempo.Interpolation.Collection {
             -> Builder
         {
             self.intermediate.insert(Tempo.Interpolation.Fragment(interpolation), key: offset)
-            last = (offset, interpolation.end, true)
+            last = (offset, interpolation.end, nil)
             offset += interpolation.length
             return self
         }
@@ -534,19 +534,19 @@ extension Tempo.Interpolation.Collection {
         @discardableResult public func add(
             _ tempo: Tempo,
             at offset: Fraction,
-            interpolating: Bool = false
+            easing: Tempo.Interpolation.Easing? = nil
         ) -> Builder
         {
             if let (startOffset, startTempo, startInterpolating) = last {
                 let interpolation = Tempo.Interpolation(
                     start: startTempo,
-                    end: startInterpolating ? tempo : startTempo,
+                    end: startInterpolating != nil ? tempo : startTempo,
                     length: offset - startOffset,
-                    easing: .linear
+                    easing: easing ?? .linear
                 )
                 add(.init(interpolation))
             }
-            last = (offset, tempo, interpolating)
+            last = (offset, tempo, easing)
             return self
         }
     }

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -76,6 +76,7 @@ extension Tempo {
     /// - Returns: Duration in seconds for a beat at the given `subdivision`.
     public func duration(forBeatAt subdivision: Subdivision) -> Double {
         assert(subdivision.isPowerOfTwo, "Subdivision must be a power-of-two")
+        #warning("FIXME: Assert that subdivision is within bounds")
         let quotient = Double(subdivision) / Double(self.subdivision)
         return durationOfBeat / quotient
     }

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -66,7 +66,7 @@ extension Tempo {
     /// - Returns: A `Tempo` with the numerator and denominator adjusted to match the given
     /// `subdivision`.
     public func respelling(subdivision newSubdivision: Subdivision) -> Tempo {
-        assert(newSubdivision.isPowerOfTwo, "Non-power-of-two subdivisions not yet supported")
+        precondition(newSubdivision.isPowerOfTwo, "Non-power-of-two subdivisions not yet supported")
         guard newSubdivision != subdivision else { return self }
         let quotient = Double(newSubdivision) / Double(subdivision)
         let newBeatsPerMinute = beatsPerMinute * quotient
@@ -75,7 +75,7 @@ extension Tempo {
 
     /// - Returns: Duration in seconds for a beat at the given `subdivision`.
     public func duration(forBeatAt subdivision: Subdivision) -> Double {
-        assert(subdivision.isPowerOfTwo, "Subdivision must be a power-of-two")
+        precondition(subdivision.isPowerOfTwo, "Subdivision must be a power-of-two")
         #warning("FIXME: Assert that subdivision is within bounds")
         let quotient = Double(subdivision) / Double(self.subdivision)
         return durationOfBeat / quotient

--- a/Sources/MusicModel/Model.Builder.swift
+++ b/Sources/MusicModel/Model.Builder.swift
@@ -144,10 +144,10 @@ extension Model {
         @discardableResult public func add(
             _ tempo: Tempo,
             at offset: Fraction,
-            interpolating: Bool = false
+            easing: Tempo.Interpolation.Easing? = nil
         ) -> Builder
         {
-            tempoInterpolationCollectionBuilder.add(tempo, at: offset, interpolating: interpolating)
+            tempoInterpolationCollectionBuilder.add(tempo, at: offset, easing: easing)
             return self
         }
 

--- a/Tests/DurationTests/InterpolationTests.swift
+++ b/Tests/DurationTests/InterpolationTests.swift
@@ -293,4 +293,14 @@ class TempoInterpolationTests: XCTestCase {
         let interp = Tempo.Interpolation(start: Tempo(60), end: Tempo(60), length: Fraction(4,4))
         XCTAssertEqual(interp.duration, 4)
     }
+
+    func testDurationStatic120BPM() {
+        let interp = Tempo.Interpolation(start: Tempo(120), end: Tempo(120), length: Fraction(4,4))
+        XCTAssertEqual(interp.duration, 2)
+    }
+
+    func testDurationStatic30BPM() {
+        let interp = Tempo.Interpolation(start: Tempo(30), end: Tempo(30), length: Fraction(4,4))
+        XCTAssertEqual(interp.duration, 8)
+    }
 }

--- a/Tests/DurationTests/InterpolationTests.swift
+++ b/Tests/DurationTests/InterpolationTests.swift
@@ -288,4 +288,9 @@ class TempoInterpolationTests: XCTestCase {
             XCTAssertEqual(secsAtOffset, expected, accuracy: 0.01)
         }
     }
+
+    func testDurationStatic60BPM() {
+        let interp = Tempo.Interpolation(start: Tempo(60), end: Tempo(60), length: Fraction(4,4))
+        XCTAssertEqual(interp.duration, 4)
+    }
 }

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -16,7 +16,8 @@ class TempoInterpolationCollectionTests: XCTestCase {
         let builder = Tempo.Interpolation.Collection.Builder()
         builder.add(Tempo(60), at: .zero, easing: .linear)
         builder.add(Tempo(90), at: Fraction(4,4))
-        _ = builder.build()
+        let interpolations = builder.build()
+        dump(interpolations)
         #warning("Add assertion to testBuilderSingleInterpolation()")
     }
 

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -83,11 +83,15 @@ class TempoInterpolationCollectionTests: XCTestCase {
         builder.add(Tempo(30), at: Fraction(4,4))
         builder.add(Tempo(120), at: Fraction(16,4), easing: .linear)
         builder.add(Tempo(60), at: Fraction(32,4))
-        let stratum = builder.build()
-        let fragment = stratum[Fraction(3,4) ..< Fraction(17,4)]
-
-        // [3 -> 4, 4 -> 16, 16 -> 17]
-        XCTAssertEqual(fragment.count, 3)
-        #warning("Add assertion to testFragment()")
+        let interpolations = builder.build()
+        let fragment = interpolations[Fraction(3,4) ..< Fraction(17,4)]
+        let a = Tempo.Interpolation(start: Tempo(60), end: Tempo(30), length: Fraction(4,4))
+        let b = Tempo.Interpolation(start: Tempo(30), end: Tempo(30), length: Fraction(12,4))
+        let c = Tempo.Interpolation(start: Tempo(120), end: Tempo(60), length: Fraction(16,4))
+        let fragmentA = Tempo.Interpolation.Fragment(a, in: Fraction(3,4)..<Fraction(4,4))
+        let fragmentB = Tempo.Interpolation.Fragment(b)
+        let fragmentC = Tempo.Interpolation.Fragment(c, in: Fraction(0,4)..<Fraction(1,4))
+        let expected = [fragmentA, fragmentB, fragmentC]
+        XCTAssertEqual(Array(fragment.spanners), expected)
     }
 }

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -12,22 +12,36 @@ import Math
 
 class TempoInterpolationCollectionTests: XCTestCase {
 
+    func testBuilderSingleStatic() {
+        let builder = Tempo.Interpolation.Collection.Builder()
+        builder.add(Tempo(60), at: .zero)
+        builder.add(Tempo(90), at: Fraction(4,4))
+        let interpolations = builder.build()
+        let expected = Tempo.Interpolation.Fragment(
+            Tempo.Interpolation(
+                start: Tempo(60),
+                end: Tempo(60),
+                length: Fraction(4,4),
+                easing: .linear
+            )
+        )
+        XCTAssertEqual(interpolations.map { _, values in values }, [expected])
+    }
+
     func testBuilderSingleInterpolation() {
         let builder = Tempo.Interpolation.Collection.Builder()
         builder.add(Tempo(60), at: .zero, easing: .linear)
         builder.add(Tempo(90), at: Fraction(4,4))
         let interpolations = builder.build()
-        dump(interpolations)
-        #warning("Add assertion to testBuilderSingleInterpolation()")
-    }
-
-    func testBuilderSingleStatic() {
-        let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(60), at: .zero)
-        builder.add(Tempo(90), at: Fraction(4,4))
-        let stratum = builder.build()
-        #warning("Add assertion to testBuilderSingleStatic()")
-        print(stratum)
+        let expected = Tempo.Interpolation.Fragment(
+            Tempo.Interpolation(
+                start: Tempo(60),
+                end: Tempo(90),
+                length: Fraction(4,4),
+                easing: .linear
+            )
+        )
+        XCTAssertEqual(interpolations.map { _, values in values }, [expected])
     }
 
     func testBuilderMultipleStatic() {

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -45,13 +45,6 @@ class TempoInterpolationCollectionTests: XCTestCase {
         XCTAssertEqual(interpolations.map { _, values in values }, [expected])
     }
 
-    func testBuilderMultipleStatic() {
-        let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(120), at: Fraction(3,4))
-        let stratum = builder.build()
-        #warning("Add assertion to testBuilderMultipleStatic()")
-    }
-
     func testSimpleFragment() {
         let builder = Tempo.Interpolation.Collection.Builder()
         builder.add(Tempo(60), at: .zero, easing: .linear)

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -65,12 +65,16 @@ class TempoInterpolationCollectionTests: XCTestCase {
         builder.add(Tempo(120), at: Fraction(16,4), easing: nil)
         builder.add(Tempo(120), at: Fraction(32,4), easing: .linear)
         builder.add(Tempo(120), at: Fraction(48,4), easing: .linear)
-        let stratum = builder.build()
-        let fragment = stratum[Fraction(8,4) ..< Fraction(48,4)]
-
-        // [8 -> 16, 16 -> 32, 32 -> 48]
-        XCTAssertEqual(fragment.count, 3)
-        #warning("Add assertion to testMoreComplexFragment()")
+        let interpolations = builder.build()
+        let fragment = interpolations[Fraction(8,4) ..< Fraction(48,4)]
+        let a = Tempo.Interpolation(start: Tempo(240), end: Tempo(240), length: Fraction(12,4))
+        let b = Tempo.Interpolation(start: Tempo(120), end: Tempo(120), length: Fraction(16,4))
+        let c = Tempo.Interpolation(start: Tempo(120), end: Tempo(120), length: Fraction(16,4))
+        let fragmentA = Tempo.Interpolation.Fragment(a, in: Fraction(4,4)..<Fraction(12,4))
+        let fragmentB = Tempo.Interpolation.Fragment(b)
+        let fragmentC = Tempo.Interpolation.Fragment(c)
+        let expected = [fragmentA, fragmentB, fragmentC]
+        XCTAssertEqual(Array(fragment.spanners), expected)
     }
 
     func testFragment() {

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -25,7 +25,8 @@ class TempoInterpolationCollectionTests: XCTestCase {
                 easing: .linear
             )
         )
-        XCTAssertEqual(interpolations.map { _, values in values }, [expected])
+        XCTAssertEqual(Array(interpolations.offsets), [Fraction(0,4)])
+        XCTAssertEqual(Array(interpolations.spanners), [expected])
     }
 
     func testBuilderSingleInterpolation() {

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -10,14 +10,14 @@ import XCTest
 import Math
 @testable import Duration
 
-class StratumTests: XCTestCase {
+class TempoInterpolationCollectionTests: XCTestCase {
 
     func testBuilderSingleInterpolation() {
         let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(60), at: .zero, interpolating: true)
+        builder.add(Tempo(60), at: .zero, easing: .linear)
         builder.add(Tempo(90), at: Fraction(4,4))
         _ = builder.build()
-        // TODO: Assert
+        #warning("Add assertion to testBuilderSingleInterpolation()")
     }
 
     func testBuilderSingleStatic() {
@@ -25,6 +25,7 @@ class StratumTests: XCTestCase {
         builder.add(Tempo(60), at: .zero)
         builder.add(Tempo(90), at: Fraction(4,4))
         let stratum = builder.build()
+        #warning("Add assertion to testBuilderSingleStatic()")
         print(stratum)
     }
 
@@ -32,42 +33,45 @@ class StratumTests: XCTestCase {
         let builder = Tempo.Interpolation.Collection.Builder()
         builder.add(Tempo(120), at: Fraction(3,4))
         let stratum = builder.build()
-        print(stratum)
+        #warning("Add assertion to testBuilderMultipleStatic()")
     }
 
     func testSimpleFragment() {
         let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(60), at: .zero, interpolating: true)
+        builder.add(Tempo(60), at: .zero, easing: .linear)
         builder.add(Tempo(120), at: Fraction(32,4))
         let stratum: Tempo.Interpolation.Collection = builder.build()
         let fragment = stratum[.zero ..< Fraction(32,4)]
         XCTAssertEqual(fragment.count, 1)
+        #warning("Add assertion to testSimpleFragment()")
     }
 
     func testMoreComplexFragment() {
         let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(60), at: .zero, interpolating: true)
-        builder.add(Tempo(240), at: Fraction(4,4), interpolating: false)
-        builder.add(Tempo(120), at: Fraction(16,4), interpolating: false)
-        builder.add(Tempo(120), at: Fraction(32,4), interpolating: true)
-        builder.add(Tempo(120), at: Fraction(48,4), interpolating: true)
+        builder.add(Tempo(60), at: .zero, easing: .linear)
+        builder.add(Tempo(240), at: Fraction(4,4), easing: nil)
+        builder.add(Tempo(120), at: Fraction(16,4), easing: nil)
+        builder.add(Tempo(120), at: Fraction(32,4), easing: .linear)
+        builder.add(Tempo(120), at: Fraction(48,4), easing: .linear)
         let stratum = builder.build()
         let fragment = stratum[Fraction(8,4) ..< Fraction(48,4)]
 
         // [8 -> 16, 16 -> 32, 32 -> 48]
         XCTAssertEqual(fragment.count, 3)
+        #warning("Add assertion to testMoreComplexFragment()")
     }
 
     func testFragment() {
         let builder = Tempo.Interpolation.Collection.Builder()
-        builder.add(Tempo(60), at: .zero, interpolating: true)
-        builder.add(Tempo(30), at: Fraction(4,4), interpolating: false)
-        builder.add(Tempo(120), at: Fraction(16,4), interpolating: true)
-        builder.add(Tempo(60), at: Fraction(32,4), interpolating: false)
+        builder.add(Tempo(60), at: .zero, easing: .linear)
+        builder.add(Tempo(30), at: Fraction(4,4))
+        builder.add(Tempo(120), at: Fraction(16,4), easing: .linear)
+        builder.add(Tempo(60), at: Fraction(32,4))
         let stratum = builder.build()
         let fragment = stratum[Fraction(3,4) ..< Fraction(17,4)]
 
         // [3 -> 4, 4 -> 16, 16 -> 17]
         XCTAssertEqual(fragment.count, 3)
+        #warning("Add assertion to testFragment()")
     }
 }

--- a/Tests/DurationTests/TempoInterpolationCollectionTests.swift
+++ b/Tests/DurationTests/TempoInterpolationCollectionTests.swift
@@ -51,8 +51,11 @@ class TempoInterpolationCollectionTests: XCTestCase {
         builder.add(Tempo(120), at: Fraction(32,4))
         let stratum: Tempo.Interpolation.Collection = builder.build()
         let fragment = stratum[.zero ..< Fraction(32,4)]
+        let expected = Tempo.Interpolation.Fragment(
+            Tempo.Interpolation(start: Tempo(60), end: Tempo(120), length: Fraction(32,4))
+        )
         XCTAssertEqual(fragment.count, 1)
-        #warning("Add assertion to testSimpleFragment()")
+        XCTAssertEqual(fragment.spanners.first!, expected)
     }
 
     func testMoreComplexFragment() {

--- a/Tests/DurationTests/TempoInterpolationFragmentTests.swift
+++ b/Tests/DurationTests/TempoInterpolationFragmentTests.swift
@@ -1,0 +1,31 @@
+//
+//  TempoInterpolationFragmentTests.swift
+//  DurationTests
+//
+//  Created by James Bean on 8/15/18.
+//
+
+import XCTest
+import Math
+import Duration
+
+class TempoInterpolationFragmentTests: XCTestCase {
+
+    func testSecondsOffsetStatic120BPMFirstBeats() {
+        let interp = Tempo.Interpolation(start: Tempo(60), end: Tempo(60), length: Fraction(4,4))
+        let fragment = interp[.zero..<Fraction(2,4)]
+        XCTAssertEqual(fragment.duration, 2)
+    }
+
+    func testSecondsOffsetStatic120BPMMiddleBeats() {
+        let interp = Tempo.Interpolation(start: Tempo(60), end: Tempo(60), length: Fraction(4,4))
+        let fragment = interp[Fraction(1,4)..<Fraction(3,4)]
+        XCTAssertEqual(fragment.duration, 2)
+    }
+
+    func testSecondsOffsetStatic120BPMLastBeats() {
+        let interp = Tempo.Interpolation(start: Tempo(60), end: Tempo(60), length: Fraction(4,4))
+        let fragment = interp[Fraction(2,4)..<Fraction(4,4)]
+        XCTAssertEqual(fragment.duration, 2)
+    }
+}

--- a/Tests/DurationTests/TempoTests.swift
+++ b/Tests/DurationTests/TempoTests.swift
@@ -14,23 +14,21 @@ class TempoTests: XCTestCase {
 
     func testTempoRespellingSubdivision() {
         let original = Tempo(60, subdivision: 4)
-        XCTAssertEqual(original.respelling(subdivision: 16), Tempo(240, subdivision: 16))
+        let respelled = original.respelling(subdivision: 16)
+        let expected = Tempo(240, subdivision: 16)
+        XCTAssertEqual(respelled, expected)
     }
 
-    func testInterpolationNoChange() {
-
+    func testInterpolationStatic60BPM() {
         let interpolation = Tempo.Interpolation(
             start: Tempo(60),
             end: Tempo(60),
-            length: Fraction(4,4)
+            length: Fraction(4,4),
+            easing: .linear
         )
-
-        for beatOffset in 0...4 {
-            let durationOffset = Fraction(beatOffset, 4)
-            XCTAssertEqual(
-                interpolation.secondsOffset(for: durationOffset),
-                Double(beatOffset)
-            )
-        }
+        let beatOffsets = (0...4).map { Fraction($0,4) }
+        let secondsOffsets = beatOffsets.map(interpolation.secondsOffset)
+        let expected = (0...4).map { Double($0) }
+        XCTAssertEqual(secondsOffsets, expected)
     }
 }

--- a/Tests/DurationTests/TempoTests.swift
+++ b/Tests/DurationTests/TempoTests.swift
@@ -19,7 +19,7 @@ class TempoTests: XCTestCase {
         XCTAssertEqual(respelled, expected)
     }
 
-    func testInterpolationStatic60BPM() {
+    func testInterpolationStatic60BPMSecondsOffsets() {
         let interpolation = Tempo.Interpolation(
             start: Tempo(60),
             end: Tempo(60),

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -106,7 +106,6 @@ extension RhythmTreeTests {
 
 extension TempoInterpolationCollectionTests {
     static let __allTests = [
-        ("testBuilderMultipleStatic", testBuilderMultipleStatic),
         ("testBuilderSingleInterpolation", testBuilderSingleInterpolation),
         ("testBuilderSingleStatic", testBuilderSingleStatic),
         ("testFragment", testFragment),

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -61,6 +61,13 @@ extension MeterCollectionTests {
     ]
 }
 
+extension MeterTests {
+    static let __allTests = [
+        ("testIrrationalMeter", testIrrationalMeter),
+        ("testNormalMeter", testNormalMeter),
+    ]
+}
+
 extension ProportionTreeTests {
     static let __allTests = [
         ("testInit", testInit),
@@ -97,7 +104,7 @@ extension RhythmTreeTests {
     ]
 }
 
-extension StratumTests {
+extension TempoInterpolationCollectionTests {
     static let __allTests = [
         ("testBuilderMultipleStatic", testBuilderMultipleStatic),
         ("testBuilderSingleInterpolation", testBuilderSingleInterpolation),
@@ -143,10 +150,11 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(EasingEvaluateTests.__allTests),
         testCase(EasingIntegrateTests.__allTests),
         testCase(MeterCollectionTests.__allTests),
+        testCase(MeterTests.__allTests),
         testCase(ProportionTreeTests.__allTests),
         testCase(RhythmTests.__allTests),
         testCase(RhythmTreeTests.__allTests),
-        testCase(StratumTests.__allTests),
+        testCase(TempoInterpolationCollectionTests.__allTests),
         testCase(TempoInterpolationTests.__allTests),
         testCase(TempoTests.__allTests),
     ]

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -137,7 +137,7 @@ extension TempoInterpolationTests {
 
 extension TempoTests {
     static let __allTests = [
-        ("testInterpolationNoChange", testInterpolationNoChange),
+        ("testInterpolationNoChange", testInterpolationStatic60BPM),
         ("testTempoRespellingSubdivision", testTempoRespellingSubdivision),
     ]
 }

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -137,7 +137,6 @@ extension TempoInterpolationTests {
 
 extension TempoTests {
     static let __allTests = [
-        ("testInterpolationNoChange", testInterpolationStatic60BPM),
         ("testTempoRespellingSubdivision", testTempoRespellingSubdivision),
     ]
 }

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -114,8 +114,19 @@ extension TempoInterpolationCollectionTests {
     ]
 }
 
+extension TempoInterpolationFragmentTests {
+    static let __allTests = [
+        ("testSecondsOffsetStatic120BPMFirstBeats", testSecondsOffsetStatic120BPMFirstBeats),
+        ("testSecondsOffsetStatic120BPMLastBeats", testSecondsOffsetStatic120BPMLastBeats),
+        ("testSecondsOffsetStatic120BPMMiddleBeats", testSecondsOffsetStatic120BPMMiddleBeats),
+    ]
+}
+
 extension TempoInterpolationTests {
     static let __allTests = [
+        ("testDurationStatic120BPM", testDurationStatic120BPM),
+        ("testDurationStatic30BPM", testDurationStatic30BPM),
+        ("testDurationStatic60BPM", testDurationStatic60BPM),
         ("testSecondsOffsetLinear_120to120", testSecondsOffsetLinear_120to120),
         ("testSecondsOffsetLinear_120to60_wholeNoteDuration", testSecondsOffsetLinear_120to60_wholeNoteDuration),
         ("testSecondsOffsetLinear_60to120_dottedHalfDuration", testSecondsOffsetLinear_60to120_dottedHalfDuration),
@@ -136,6 +147,7 @@ extension TempoInterpolationTests {
 
 extension TempoTests {
     static let __allTests = [
+        ("testInterpolationStatic60BPMSecondsOffsets", testInterpolationStatic60BPMSecondsOffsets),
         ("testTempoRespellingSubdivision", testTempoRespellingSubdivision),
     ]
 }
@@ -153,6 +165,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(RhythmTests.__allTests),
         testCase(RhythmTreeTests.__allTests),
         testCase(TempoInterpolationCollectionTests.__allTests),
+        testCase(TempoInterpolationFragmentTests.__allTests),
         testCase(TempoInterpolationTests.__allTests),
         testCase(TempoTests.__allTests),
     ]

--- a/Tests/DynamicsTests/XCTestManifests.swift
+++ b/Tests/DynamicsTests/XCTestManifests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+extension DynamicTests {
+    static let __allTests = [
+        ("testAPI", testAPI),
+        ("testNumericValues", testNumericValues),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(DynamicTests.__allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,12 +2,14 @@ import XCTest
 
 import ArticulationsTests
 import DurationTests
+import DynamicsTests
 import PitchTests
 import MusicModelTests
 
 var tests = [XCTestCaseEntry]()
 tests += ArticulationsTests.__allTests()
 tests += DurationTests.__allTests()
+tests += DynamicsTests.__allTests()
 tests += PitchTests.__allTests()
 tests += MusicModelTests.__allTests()
 

--- a/Tests/MusicModelTests/ModelTests.swift
+++ b/Tests/MusicModelTests/ModelTests.swift
@@ -22,7 +22,7 @@ class ModelTests: XCTestCase {
         let model = Model.Builder()
             .add(pitches, label: "pitch", with: PerformanceContext.Path(), in: interval)
             .build()
-        print(model)
+        #warning("Add assertion to testAddPitchArrayAttribute()")
     }
     
     func testPitchesAndAtriculations() {
@@ -36,6 +36,7 @@ class ModelTests: XCTestCase {
         zip(events, intervals).forEach { event, interval in builder.add(event, in: interval) }
         let model = builder.build()
         print(model)
+        #warning("Add assertion to testPitchesAndAtriculations()")
     }
     
     func testAddRhythm() {
@@ -68,6 +69,8 @@ class ModelTests: XCTestCase {
                 print(attributeIDs.map { model.values[$0] })
             }
         }
+
+        #warning("Add assertion to testAddRhythm()")
     }
     
     func testAddManyRhythms() {
@@ -95,6 +98,8 @@ class ModelTests: XCTestCase {
     
         let model = builder.build()
         print(model)
+
+        #warning("Add assertion to testAddManyRhythms()")
     }
     
     func testFilter() {
@@ -142,6 +147,8 @@ class ModelTests: XCTestCase {
             let context = model.performanceContexts[id]!
             print("\(value); interval: \(interval); contexts: \(context)")
         }
+
+        #warning("Add assertion to testFilter()")
     }
 
     
@@ -154,11 +161,13 @@ class ModelTests: XCTestCase {
         }
 
         builder.add(Tempo(90), at: .zero)
-        builder.add(Tempo(60), at: Fraction(4,4), interpolating: true)
-        builder.add(Tempo(120), at: Fraction(24,4), interpolating: false)
-        
+        builder.add(Tempo(60), at: Fraction(4,4), easing: .linear)
+        builder.add(Tempo(120), at: Fraction(24,4))
+
         let model = builder.build()
         print(model)
         // TODO: Assert something!
+
+        #warning("Add assertion to testAddMeterStructure()")
     }
 }


### PR DESCRIPTION
Currently, merely a `Bool` is passed into the `Tempo.Interpolation.Collection.Builder` to indicate whether the following `Tempo` should interpolate to the next with a `.linear` easing (i.e., there is no choice of curve). 

This PR replaces the `Bool` with an `Optional<Tempo.Interpolation.Easing>`, which specifies the curve, if it is desired. Otherwise, a `nil` can be passed in if no interpolation is desired.