### PR TITLE
Refactor SpanningContainer(Builder) to use OrderedDictionary

### DIFF
--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -124,7 +124,7 @@ extension Meter.Collection {
         // MARK: - Instance Properties
 
         /// The value which will ultimately be the underlying storage of a `Meter.Collection`.
-        public var intermediate: SortedDictionary<Fraction,Meter.Fragment>
+        public var intermediate: OrderedDictionary<Fraction,Meter.Fragment>
 
         /// The accumulating offset of `Fraction` keys.
         public var offset: Fraction

--- a/Sources/Duration/Spanning/SpanningContainerBuilder.swift
+++ b/Sources/Duration/Spanning/SpanningContainerBuilder.swift
@@ -28,7 +28,7 @@ public protocol SpanningContainerBuilder: class {
     /// Intermediate storage which is converted into the `Product`.
     //
     // FIXME: Consider using `OrderedDictionary` re: performance.
-    var intermediate: SortedDictionary<Spanner.Metric,Spanner> { get set }
+    var intermediate: OrderedDictionary<Spanner.Metric,Spanner> { get set }
 
     /// Cumulative offset of spanners contained in `intermediate`.
     var offset: Spanner.Metric { get set }
@@ -48,7 +48,7 @@ extension SpanningContainerBuilder {
     ///
     /// - Returns: `Self`.
     @discardableResult public func add(_ element: Spanner) -> Self {
-        intermediate.insert(element, key: offset)
+        intermediate.append(element, key: offset)
         offset = offset + element.range.length
         return self
     }
@@ -65,6 +65,6 @@ extension SpanningContainerBuilder {
 
     /// Creates the final `Product` with the `intermediate`.
     public func build() -> Product {
-        return Product(intermediate)
+        return Product(SortedDictionary(intermediate.map { $0 }))
     }
 }

--- a/Sources/Duration/Tempo/Tempo.swift
+++ b/Sources/Duration/Tempo/Tempo.swift
@@ -499,8 +499,7 @@ extension Tempo.Interpolation.Collection {
 
         /// The intermediate storage of `Tempo.Interpolation.Fragment` values indexed by their
         /// `Fraction` offsets.
-        // FIXME: Consider using an `OrderedDictionary` re: performance.
-        public var intermediate: SortedDictionary<Fraction,Tempo.Interpolation.Fragment>
+        public var intermediate: OrderedDictionary<Fraction,Tempo.Interpolation.Fragment>
 
         // MARK: - Initializers
 
@@ -520,7 +519,7 @@ extension Tempo.Interpolation.Collection {
         @discardableResult public func add(_ fragment: Tempo.Interpolation.Fragment)
             -> Builder
         {
-            self.intermediate.insert(fragment, key: offset)
+            self.intermediate.append(fragment, key: offset)
             last = (offset, fragment.base.end, nil)
             offset += fragment.range.length
             return self
@@ -533,7 +532,7 @@ extension Tempo.Interpolation.Collection {
         @discardableResult public func add(_ interpolation: Tempo.Interpolation)
             -> Builder
         {
-            self.intermediate.insert(Tempo.Interpolation.Fragment(interpolation), key: offset)
+            self.intermediate.append(Tempo.Interpolation.Fragment(interpolation), key: offset)
             last = (offset, interpolation.end, nil)
             offset += interpolation.length
             return self


### PR DESCRIPTION
The backing store for a `SpanningContainer` is a `SortedDictionary`. Currently, a `SpanningContainerBuilder` uses a `SortedDictionary` throughout its build process to statefully construct its `Product`. However, the interface for `SpanningContainingBuilder` only exposes `append`-like methods anyway, making the continual performance blow of using `SortedArray` underneath unnecessary.

This PR refactors the `SpanningContainerBuilder` process to utilize `OrderedDictionary` under the hood instead of `SortedDictionary`.