### PR TITLE
Add Chord and Scale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode9.4
+osx_image: xcode10
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
-  - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2018-05-30-a
+  - SWIFT_VERSION=4.2
 script:
   - swift package update
   - swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
           "branch": null,
-          "revision": "f51237583d0e0e0779dcffc7e471a2cabab359f1",
-          "version": "0.18.0"
+          "revision": "ee95d59a077e28d956500a88b41ef9247f8ae0c6",
+          "version": "0.19.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "MusicModel", targets: ["MusicModel"])
     ],
     dependencies: [
-        .package(url: "https://github.com/dn-m/Structure", .upToNextMinor(from: "0.18.0")),
+        .package(url: "https://github.com/dn-m/Structure", .upToNextMinor(from: "0.19.0")),
         .package(url: "https://github.com/dn-m/Math", from: "0.6.0")
     ],
     targets: [

--- a/Sources/Pitch/Chord.swift
+++ b/Sources/Pitch/Chord.swift
@@ -1,0 +1,11 @@
+//
+//  Chord.swift
+//  Pitch
+//
+//  Created by James Bean on 10/9/18.
+//
+
+public struct Chord {
+    let first: Pitch
+    let intervals: [Pitch]
+}

--- a/Sources/Pitch/Chord.swift
+++ b/Sources/Pitch/Chord.swift
@@ -5,20 +5,40 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import DataStructures
+
 public struct Chord {
 
     // MARK: - Instance Properties
 
     let first: Pitch
-    let intervals: [Pitch]
+    let intervals: IntervalPattern
+}
+
+extension Chord {
+
+    // MARK: - Nested Types
+
+    public struct IntervalPattern {
+        let intervals: [Pitch]
+    }
 }
 
 extension Chord {
 
     // MARK: - Initializers
 
-    init(_ first: Pitch, _ intervals: [Pitch]) {
+    init(_ first: Pitch, _ intervals: IntervalPattern) {
         self.first = first
         self.intervals = intervals
+    }
+}
+
+extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral intervals: Pitch...) {
+        self.init(intervals: intervals)
     }
 }

--- a/Sources/Pitch/Chord.swift
+++ b/Sources/Pitch/Chord.swift
@@ -6,6 +6,19 @@
 //
 
 public struct Chord {
+
+    // MARK: - Instance Properties
+
     let first: Pitch
     let intervals: [Pitch]
+}
+
+extension Chord {
+
+    // MARK: - Initializers
+
+    init(_ first: Pitch, _ intervals: [Pitch]) {
+        self.first = first
+        self.intervals = intervals
+    }
 }

--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -1,0 +1,25 @@
+//
+//  Chord.IntervalPattern.swift
+//  Pitch
+//
+//  Created by James Bean on 10/9/18.
+//
+
+extension Chord {
+
+    // MARK: - Nested Types
+
+    public struct IntervalPattern {
+        let intervals: [Pitch]
+    }
+}
+
+extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral intervals: Pitch...) {
+        self.init(intervals: intervals)
+    }
+}
+

--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -14,6 +14,11 @@ extension Chord {
     }
 }
 
+extension Chord.IntervalPattern {
+    static var major: Chord.IntervalPattern { return [4,3] }
+    static var minor: Chord.IntervalPattern { return [3,4] }
+}
+
 extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
@@ -22,4 +27,3 @@ extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
         self.init(intervals: intervals)
     }
 }
-

--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -15,6 +15,13 @@ extension Chord {
 }
 
 extension Chord.IntervalPattern {
+
+    public init(_ intervals: [Pitch]) {
+        self.init(intervals: intervals)
+    }
+}
+
+extension Chord.IntervalPattern {
     static var major: Chord.IntervalPattern { return [4,3] }
     static var minor: Chord.IntervalPattern { return [3,4] }
 }
@@ -27,3 +34,6 @@ extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
         self.init(intervals: intervals)
     }
 }
+
+extension Chord.IntervalPattern: Equatable { }
+extension Chord.IntervalPattern: Hashable { }

--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -5,6 +5,8 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import DataStructures
+
 extension Chord {
 
     // MARK: - Nested Types
@@ -32,6 +34,12 @@ extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
 
     public init(arrayLiteral intervals: Pitch...) {
         self.init(intervals: intervals)
+    }
+}
+
+extension Chord.IntervalPattern: CollectionWrapping {
+    public var base: [Pitch] {
+        return intervals
     }
 }
 

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -17,28 +17,10 @@ public struct Chord {
 
 extension Chord {
 
-    // MARK: - Nested Types
-
-    public struct IntervalPattern {
-        let intervals: [Pitch]
-    }
-}
-
-extension Chord {
-
     // MARK: - Initializers
 
     init(_ first: Pitch, _ intervals: IntervalPattern) {
         self.first = first
         self.intervals = intervals
-    }
-}
-
-extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
-
-    // MARK: - ExpressibleByArrayLiteral
-
-    public init(arrayLiteral intervals: Pitch...) {
-        self.init(intervals: intervals)
     }
 }

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -20,8 +20,8 @@ extension Chord {
     // MARK: - Initializers
 
     /// Creates a `Chord` with the given `first` pitch and the given `intervals`.
-    init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
+    init(_ lowest: Pitch, _ intervals: IntervalPattern) {
+        self.pitches = [lowest] + intervals.accumulatingSum.map { $0 + lowest }
     }
 
     /// Creates a `Chord` with the pitches in the given `sequence`.

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -5,6 +5,7 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import Destructure
 import DataStructures
 
 public struct Chord {
@@ -23,4 +24,22 @@ extension Chord {
         self.first = first
         self.intervals = intervals
     }
+
+    init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
+        let sorted = sequence.sorted()
+        precondition(!sorted.isEmpty, "Cannot create a 'Chord' with an empty sequence of pitches")
+        self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
+    }
 }
+
+extension Chord: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral pitches: Pitch...) {
+        self.init(pitches)
+    }
+}
+
+extension Chord: Equatable { }
+extension Chord: Hashable { }

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -12,19 +12,19 @@ public struct Chord {
 
     // MARK: - Instance Properties
 
-    let first: Pitch
-    let intervals: IntervalPattern
+    let pitches: [Pitch]
 }
 
 extension Chord {
 
     // MARK: - Initializers
 
+    /// Creates a `Chord` with the given `first` pitch and the given `intervals`.
     init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.first = first
-        self.intervals = intervals
+        self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
     }
 
+    /// Creates a `Chord` with the pitches in the given `sequence`.
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
         let sorted = sequence.sorted()
         precondition(!sorted.isEmpty, "Cannot create a 'Chord' with an empty sequence of pitches")

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -1,0 +1,40 @@
+//
+//  CompoundIntervalDescriptor.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+/// A descriptor for intervals between two `Pitch` values which takes into account octave
+/// displacement.
+public struct CompoundIntervalDescriptor: IntervalDescriptor {
+
+    // MARK: - Instance Properties
+
+    /// The base interval descriptor.
+    public let interval: OrderedIntervalDescriptor
+
+    /// The amount of octaves displaced.
+    public let octaveDisplacement: Int
+}
+
+extension CompoundIntervalDescriptor {
+
+    // MARK: - Initializers
+
+    /// Creates a `CompoundIntervalDescriptor` with the given `interval` and the amount of `octaves`
+    /// of displacement.
+    public init(_ interval: OrderedIntervalDescriptor, displacedBy octaves: Int = 0) {
+        self.interval = interval
+        self.octaveDisplacement = octaves
+    }
+
+    /// Creates a `CompoundIntervalDescriptor` with the given `quality` and the given `ordinal`,
+    /// with no octave displacement.
+    public init(_ quality: IntervalQuality, _ ordinal: OrderedIntervalDescriptor.Ordinal) {
+        self.init(OrderedIntervalDescriptor(quality,ordinal))
+    }
+}
+
+extension CompoundIntervalDescriptor: Equatable { }
+extension CompoundIntervalDescriptor: Hashable { }

--- a/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
@@ -1,0 +1,8 @@
+//
+//  IntervalDescriptor.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import Foundation

--- a/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
@@ -5,4 +5,77 @@
 //  Created by James Bean on 10/10/18.
 //
 
-import Foundation
+/// Interface for intervals between two `Pitch` values.
+protocol IntervalDescriptor {
+
+    // MARK: - Associated Types
+
+    /// The `IntervalOrdinal`-conforming type for this `IntervalDescriptor`.
+    associatedtype Ordinal: IntervalOrdinal
+
+    // MARK: - Initializers
+
+    /// Creates a `IntervalDescriptor` with the given `quality` and the given `ordinal`.
+    init(_ quality: IntervalQuality, _ ordinal: Ordinal)
+}
+
+extension IntervalDescriptor {
+
+    /// Createss a `IntervalDescriptor`-conforming type with the given `interval` (i.e., the distance
+    /// between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values) and the given
+    /// `steps` (i.e., the distance between the `LetterName` attributes of `Pitch.Spelling`
+    /// values).
+    init(interval: Double, steps: Int) {
+        let (quality,ordinal) = Self.qualityAndOrdinal(interval: interval, steps: steps)
+        self.init(quality,ordinal)
+    }
+
+    /// - Returns the `IntervalQuality` and `Ordinal` values for the given `interval` (i.e.,
+    /// the distance between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values)
+    /// and the given `steps (i.e., the distance between the `LetterName` attributes of
+    ///`Pitch.Spelling`  values).
+    static func qualityAndOrdinal(interval: Double, steps: Int)
+        -> (IntervalQuality, Ordinal)
+    {
+        let distance = Ordinal.platonicDistance(from: interval, to: steps)
+        let ordinal = Ordinal(steps: steps)!
+        let quality = IntervalQuality(distance: distance, with: ordinal.platonicThreshold)
+        return (quality, ordinal)
+    }
+}
+
+extension IntervalQuality {
+    init(distance: Double, with platonicThreshold: Double) {
+        let (diminished, augmented) = (-platonicThreshold,platonicThreshold)
+        switch distance {
+        case diminished - 4:
+            self =  .extended(.init(.quintuple, .diminished))
+        case diminished - 3:
+            self = .extended(.init(.quadruple, .diminished))
+        case diminished - 2:
+            self = .extended(.init(.triple, .diminished))
+        case diminished - 1:
+            self = .extended(.init(.double, .diminished))
+        case diminished:
+            self = .extended(.init(.single, .diminished))
+        case -0.5:
+            self = .imperfect(.minor)
+        case +0.0:
+            self = .perfect(.perfect)
+        case +0.5:
+            self = .imperfect(.major)
+        case augmented:
+            self = .extended(.init(.single, .augmented))
+        case augmented + 1:
+            self = .extended(.init(.double, .augmented))
+        case augmented + 2:
+            self = .extended(.init(.triple, .augmented))
+        case augmented + 3:
+            self = .extended(.init(.quadruple, .augmented))
+        case augmented + 4:
+            self = .extended(.init(.quintuple, .augmented))
+        default:
+            fatalError("Not possible to create a NamedIntervalQuality with interval \(distance)")
+        }
+    }
+}

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -1,0 +1,43 @@
+//
+//  IntervalOrdinal.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import Math
+
+/// Interface for `IntervalOrdinal`-like values.
+protocol IntervalOrdinal {
+
+    // MARK: - Type Properties
+
+    /// The distance between the given `steps` and the platonic ideal for this
+    /// `IntervalOrdinal` value.
+    static func platonicInterval(steps: Int) -> Double
+
+    // MARK: - Instance Properties
+
+    /// The distance from the platonic ideal interval where the interval quality becomes diminished
+    /// or augmented.
+    var platonicThreshold: Double { get }
+
+    // MARK: - Initializers
+
+    /// Creates a `IntervalOrdinal` with the given amount of `steps`.
+    init?(steps: Int)
+}
+
+extension IntervalOrdinal {
+
+    // MARK: - Type Methods
+
+    /// - Returns: The distance of the given `interval` to the `platonicInterval` from the given
+    /// `steps`.
+    static func platonicDistance(from interval: Double, to steps: Int) -> Double {
+        let ideal = Self.platonicInterval(steps: steps)
+        let difference = interval - ideal
+        let normalized = mod(difference + 6, 12) - 6
+        return steps == 0 ? abs(normalized) : normalized
+    }
+}

--- a/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
@@ -1,0 +1,134 @@
+//
+//  IntervalQuality.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import Algebra
+import DataStructures
+
+/// The quality of an interval between two `Pitch` values.
+public enum IntervalQuality: Invertible {
+
+    // MARK: - Cases
+
+    /// Perfect interval qualities (e.g., perfect).
+    case perfect(Perfect)
+
+    /// Imperfect interval qualities (e.g., major or minor).
+    case imperfect(Imperfect)
+
+    /// Extended interval qualities (e.g., augmented or diminished).
+    case extended(Extended)
+}
+
+extension IntervalQuality {
+
+    // MARK: - Nested Types
+
+    /// A perfect interval quality.
+    public enum Perfect {
+
+        // MARK: - Cases
+
+        /// Perfect interval quality.
+        case perfect
+    }
+
+    /// An imperfect interval quality.
+    public enum Imperfect: InvertibleEnum {
+
+        // MARK: - Cases
+
+        /// Major interval quality.
+        case major
+
+        /// Minor interval quality.
+        case minorn
+    }
+
+    /// An augmented or diminished interval quality
+    public struct Extended: Invertible {
+
+        // MARK: Instance Properties
+
+        /// - Returns: Inversion of `self`.
+        public var inverse: Extended {
+            return Extended(degree, quality.inverse)
+        }
+
+        /// Whether this `Extended` quality is augmented or diminished
+        let quality: AugmentedOrDiminished
+
+        /// The degree to which this quality is augmented or diminished (e.g., double augmented,
+        /// etc.)
+        let degree: Degree
+
+        // MARK: Initializers
+
+        /// Createss an `Extended` `NamedIntervalQuality` with the given `degree` and `quality.`
+        public init(_ degree: Degree = .single, _ quality: AugmentedOrDiminished) {
+            self.degree = degree
+            self.quality = quality
+        }
+    }
+}
+
+extension IntervalQuality.Extended {
+
+    // MARK: - Nested Types
+
+    /// Either augmented or diminished
+    public enum AugmentedOrDiminished: InvertibleEnum {
+
+        // MARK: - Cases
+
+        /// Augmented extended interval quality.
+        case augmented
+
+        /// Diminished extended interval quality.
+        case diminished
+    }
+
+    /// The degree to which an `Extended` quality is augmented or diminished.
+    public enum Degree: Int {
+
+        /// Single extended interval quality degree.
+        case single = 1
+
+        /// Double extended interval quality degree.
+        case double = 2
+
+        /// Triple extended interval quality degree.
+        case triple = 3
+
+        /// Quadruple extended interval quality degree.
+        case quadruple = 4
+
+        /// Quintuple extended interval quality degree.
+        case quintuple = 5
+    }
+}
+
+extension IntervalQuality {
+
+    // MARK: - Instance Properties
+
+    /// - Returns: Inversion of `self`
+    public var inverse: IntervalQuality {
+        switch self {
+        case .perfect:
+            return .perfect(.perfect)
+        case .imperfect(let quality):
+            return .imperfect(quality.inverse)
+        case .extended(let quality):
+            return .extended(quality.inverse)
+        }
+    }
+}
+
+extension IntervalQuality.Extended: Equatable { }
+extension IntervalQuality.Extended: Hashable { }
+extension IntervalQuality: Equatable { }
+extension IntervalQuality: Hashable { }

--- a/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
@@ -45,7 +45,7 @@ extension IntervalQuality {
         case major
 
         /// Minor interval quality.
-        case minorn
+        case minor
     }
 
     /// An augmented or diminished interval quality

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -1,0 +1,395 @@
+//
+//  OrderedIntervalDescriptor.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import Algebra
+import DataStructures
+
+/// Descriptor for ordered interval between two `Pitch` values.
+public struct OrderedIntervalDescriptor: IntervalDescriptor {
+
+    // MARK: - Instance Properties
+
+    /// The direction of a `OrderedIntervalDescriptor`.
+    public let direction: Direction
+
+    /// Ordinal value of a `OrderedIntervalDescriptor`
+    /// (`unison`, `second`, `third`, `fourth`, `fifth`, `sixth`, `seventh`).
+    public let ordinal: Ordinal
+
+    /// IntervalQuality value of a `OrderedIntervalDescriptor`.
+    /// (`diminished`, `minor`, `perfect`, `major`, `augmented`).
+    public let quality: IntervalQuality
+}
+
+extension OrderedIntervalDescriptor {
+
+    // MARK: - Nested Types
+
+    /// Direction of a `OrderedIntervalDescriptor`.
+    public enum Direction: InvertibleEnum {
+        case ascending, descending
+    }
+
+    /// Ordinal for `OrderedIntervalDescriptor`.
+    public enum Ordinal: IntervalOrdinal {
+
+        // MARK: - Cases
+
+        /// Perfect ordered interval ordinal (unison, fourth, or fifth).
+        case perfect(Perfect)
+
+        /// Imperfect ordered interval ordinal (second, third, sixth, or seventh).
+        case imperfect(Imperfect)
+
+        /// - Returns: Inversion of `self`.
+        ///
+        ///     let third: Ordinal = .imperfect(.third)
+        ///     third.inverse // => .imperfect(.sixth)
+        ///     let fifth: Ordinal = .perfect(.fifth)
+        ///     fifth.inverse // => .perfect(.fourth)
+        ///
+        public var inverse: OrderedIntervalDescriptor.Ordinal {
+            switch self {
+            case .perfect(let ordinal):
+                return .perfect(ordinal.inverse)
+            case .imperfect(let ordinal):
+                return .imperfect(ordinal.inverse)
+            }
+        }
+    }
+}
+
+extension OrderedIntervalDescriptor.Ordinal {
+
+    // MARK: - Nested Types
+
+    /// Perfect `Ordinal` cases.
+    public enum Perfect: InvertibleEnum {
+
+        // MARK: - Cases
+
+        /// Fourth perfect ordered interval ordinal.
+        case fourth
+
+        /// Unison perfect ordered interval ordinal.
+        case unison
+
+        /// Fifth perfect ordered interval ordinal.
+        case fifth
+    }
+
+    /// Imperfect `Ordinal` cases
+    public enum Imperfect: InvertibleEnum {
+
+        // MARK: - Cases
+
+        /// Second imperfect ordered interval ordinal.
+        case second
+
+        /// Third imperfect ordered interval ordinal.
+        case third
+
+        /// Sixth imperfect ordered interval ordinal.
+        case sixth
+
+        /// Seventh imperfect ordered interval ordinal.
+        case seventh
+    }
+}
+
+extension OrderedIntervalDescriptor.Ordinal {
+
+    // MARK: - Initializers
+
+    /// Creates a `OrderedIntervalDescriptor` with the given amount of `steps`.
+    public init?(steps: Int) {
+        switch steps {
+        case 0: self = .perfect(.unison)
+        case 1: self = .imperfect(.second)
+        case 2: self = .imperfect(.third)
+        case 3: self = .perfect(.fourth)
+        case 4: self = .perfect(.fifth)
+        case 5: self = .imperfect(.sixth)
+        case 6: self = .imperfect(.seventh)
+        default: return nil
+        }
+    }
+
+    /// Creates an `OrderedIntervalDescriptor` with the given `unordered` interval.
+    ///
+    /// - Warning: This is a lossless conversion.
+    ///
+    public init(_ unordered: UnorderedIntervalDescriptor.Ordinal) {
+        switch unordered {
+        case .perfect(let perfect):
+            switch perfect {
+            case .unison:
+                self = .perfect(.unison)
+            case .fourth:
+                self = .perfect(.fourth)
+            }
+        case .imperfect(let imperfect):
+            switch imperfect {
+            case .second:
+                self = .imperfect(.second)
+            case .third:
+                self = .imperfect(.third)
+            }
+        }
+    }
+}
+
+extension OrderedIntervalDescriptor.Ordinal {
+    var platonicThreshold: Double {
+        switch self {
+        case .perfect:
+            return 1
+        case .imperfect:
+            return 1.5
+        }
+    }
+
+    static func platonicInterval(steps: Int) -> Double {
+        assert((0..<7).contains(steps))
+        switch steps {
+        case 0:
+            return 0
+        case 1:
+            return 1.5
+        case 2:
+            return 3.5
+        case 3:
+            return 5
+        case 4:
+            return 7
+        case 5:
+            return 8.5
+        case 6:
+            return 10.5
+        default:
+            fatalError("Impossible")
+        }
+    }
+}
+
+
+extension OrderedIntervalDescriptor {
+
+    // MARK: - Type Properties
+
+    /// Unison named ordered interval.
+    public static var unison: OrderedIntervalDescriptor {
+        return .init(.perfect, .unison)
+    }
+}
+
+extension OrderedIntervalDescriptor {
+
+    // MARK: - Initializers
+
+    /// Creates an `OrderedIntervalDescriptor` with a given `quality` and `ordinal`.
+    internal init(_ direction: Direction, _ quality: IntervalQuality, _ ordinal: Ordinal) {
+        self.direction = direction
+        self.quality = quality
+        self.ordinal = ordinal
+    }
+
+    /// Creates an `OrderedIntervalDescriptor` with a given `quality` and `ordinal`.
+    internal init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
+        self.direction = .ascending
+        self.quality = quality
+        self.ordinal = ordinal
+    }
+
+    /// Creates a perfect `OrderedIntervalDescriptor`.
+    ///
+    ///     let perfectFifth = OrderedIntervalDescriptor(.perfect, .fifth)
+    ///
+    public init(_ quality: IntervalQuality.Perfect, _ ordinal: Ordinal.Perfect) {
+        self.direction = .ascending
+        self.quality = .perfect(.perfect)
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates a perfect `OrderedIntervalDescriptor` with a given `direction`.
+    ///
+    ///     let descendingPerfectFifth = OrderedIntervalDescriptor(.descending, .perfect, .fifth)
+    ///
+    public init(_ direction: Direction, _ quality: IntervalQuality.Perfect, _ ordinal: Ordinal.Perfect) {
+        self.direction = direction
+        self.quality = .perfect(.perfect)
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates an imperfect `OrderedIntervalDescriptor`.
+    ///
+    ///     let majorSecond = OrderedIntervalDescriptor(.major, .second)
+    ///     let minorThird = OrderedIntervalDescriptor(.minor, .third)
+    ///     let majorSixth = OrderedIntervalDescriptor(.major, .sixth)
+    ///     let minorSeventh = OrderedIntervalDescriptor(.minor, .seventh)
+    ///
+    public init(_ quality: IntervalQuality.Imperfect, _ ordinal: Ordinal.Imperfect) {
+        self.direction = .ascending
+        self.quality = .imperfect(quality)
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an imperfect `OrderedIntervalDescriptor`.
+    ///
+    ///     let majorSecond = OrderedIntervalDescriptor(.ascending, .major, .second)
+    ///     let minorThird = OrderedIntervalDescriptor(.descending, .minor, .third)
+    ///     let majorSixth = OrderedIntervalDescriptor(.ascending, .major, .sixth)
+    ///     let minorSeventh = OrderedIntervalDescriptor(.descending, .minor, .seventh)
+    ///
+    public init(
+        _ direction: Direction,
+        _ quality: IntervalQuality.Imperfect,
+        _ ordinal: Ordinal.Imperfect
+        )
+    {
+        self.direction = direction
+        self.quality = .imperfect(quality)
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with an imperfect ordinal. These
+    /// intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleDiminishedSecond = OrderedIntervalDescriptor(.double, .diminished, .second)
+    ///     let tripleAugmentedThird = OrderedIntervalDescriptor(.triple, .augmented, .third)
+    ///
+    public init(
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Imperfect
+        )
+    {
+        self.direction = .ascending
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a given `direction` and an
+    /// imperfect ordinal. These intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleDiminishedSecond = OrderedIntervalDescriptor(.descending, .double, .diminished, .second)
+    ///     let tripleAugmentedThird = OrderedIntervalDescriptor(.ascending, .triple, .augmented, .third)
+    ///
+    public init(
+        _ direction: Direction,
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Imperfect
+        )
+    {
+        self.direction = direction
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a perfect ordinal. These
+    /// intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleAugmentedUnison = OrderedIntervalDescriptor(.double, .augmented, .unison)
+    ///     let tripleDiminishedFourth = OrderedIntervalDescriptor(.triple, .diminished, .fourth)
+    ///
+    public init(
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Perfect
+        )
+    {
+        self.direction = .ascending
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a given `direction` and a
+    /// perfect ordinal. These intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleAugmentedUnison = OrderedIntervalDescriptor(.descending, .double, .augmented, .unison)
+    ///     let tripleDiminishedFourth = OrderedIntervalDescriptor(.ascending, .triple, .diminished, .fourth)
+    ///
+    public init(
+        _ direction: Direction,
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Perfect
+        )
+    {
+        self.direction = direction
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with an imperfect ordinal.
+    ///
+    ///     let diminishedSecond = OrderedIntervalDescriptor(.diminished, .second)
+    ///     let augmentedSixth = OrderedIntervalDescriptor(.augmented, .sixth)
+    ///
+    public init(_ quality: IntervalQuality.Extended.AugmentedOrDiminished, _ ordinal: Ordinal.Imperfect) {
+        self.direction = .ascending
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a given `direction` and an
+    /// imperfect ordinal.
+    ///
+    ///     let diminishedSecond = OrderedIntervalDescriptor(.descending, .diminished, .second)
+    ///     let augmentedSixth = OrderedIntervalDescriptor(.ascending, .augmented, .sixth)
+    ///
+    public init(
+        _ direction: Direction,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Imperfect
+        )
+    {
+        self.direction = direction
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a perfect ordinal.
+    ///
+    ///     let augmentedUnison = OrderedIntervalDescriptor(.augmented, .unison)
+    ///     let diminishedFourth = OrderedIntervalDescriptor(.diminished, .fourth)
+    ///
+    public init(_ quality: IntervalQuality.Extended.AugmentedOrDiminished, _ ordinal: Ordinal.Perfect) {
+        self.direction = .ascending
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedIntervalDescriptor` with a given `direction` and a
+    /// perfect ordinal.
+    ///
+    ///     let augmentedUnison = OrderedIntervalDescriptor(.ascending, .augmented, .unison)
+    ///     let diminishedFourth = OrderedIntervalDescriptor(.descending, .diminished, .fourth)
+    ///
+    public init(
+        _ direction: Direction,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Perfect
+        )
+    {
+        self.direction = direction
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+}
+
+extension OrderedIntervalDescriptor.Ordinal: Equatable, Hashable { }
+extension OrderedIntervalDescriptor: Equatable, Hashable { }
+
+extension OrderedIntervalDescriptor: Invertible {
+
+    /// - Returns: Inversion of `self`.
+    public var inverse: OrderedIntervalDescriptor {
+        return .init(direction.inverse, quality.inverse, ordinal.inverse)
+    }
+}

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -1,0 +1,262 @@
+//
+//  UnorderedIntervalDescriptor.swift
+//  Pitch
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import Algorithms
+import Math
+
+/// Descriptor for unordered intervals between two `Pitch.Class` values.
+public struct UnorderedIntervalDescriptor: IntervalDescriptor {
+
+    // MARK: - Instance Properties
+
+    /// Quality of an `UnorderedIntervalDescriptor`.
+    ///
+    /// - `diminished`
+    /// - `minor`
+    /// - `perfect`
+    /// - `major`
+    /// - `augmented`
+    ///
+    public let quality: IntervalQuality
+
+    /// Ordinal of an `UnorderedIntervalDescriptor`.
+    ///
+    /// - `unison`
+    /// - `second`
+    /// - `third`
+    /// - `fourth`
+    ///
+    public let ordinal: Ordinal
+}
+
+extension UnorderedIntervalDescriptor {
+
+    // MARK: - Nested Types
+
+    /// The ordinal of a `UnorderedIntervalDescriptor`.
+    public enum Ordinal: IntervalOrdinal {
+
+        // MARK: - Cases
+
+        /// Imperfect unordered interval ordinals (e.g., unison, fourth).
+        case perfect(Perfect)
+
+        /// Perfect unordered interval ordinals (e.g., second, third).
+        case imperfect(Imperfect)
+    }
+}
+
+extension UnorderedIntervalDescriptor.Ordinal {
+
+    // MARK: - Initializers
+
+    /// Createss a `UnorderedIntervalDescriptor` with the given amount of `steps`.
+    public init?(steps: Int) {
+        switch steps {
+        case 0: self = .perfect(.unison)
+        case 1: self = .imperfect(.second)
+        case 2: self = .imperfect(.third)
+        case 3: self = .perfect(.fourth)
+        default: return nil
+        }
+    }
+
+    /// Creates an `UnorderedIntervalDescriptor` with the given `ordered` interval.
+    ///
+    /// In the case that the `ordered` interval is out of range (e.g., `.fifth`, `.sixth`,
+    /// `.seventh`), the `.inverse` is converted into an unordered interval (e.g., a `.seventh`
+    /// becomes a `.second`).
+    ///
+    public init(_ ordered: OrderedIntervalDescriptor.Ordinal) {
+        switch ordered {
+        case .perfect(let perfect):
+            switch perfect {
+            case .unison:
+                self = .perfect(.unison)
+            case .fourth:
+                self = .perfect(.fourth)
+            case .fifth:
+                self.init(ordered.inverse)
+            }
+        case .imperfect(let imperfect):
+            switch imperfect {
+            case .second:
+                self = .imperfect(.second)
+            case .third:
+                self = .imperfect(.third)
+            case .sixth:
+                self.init(ordered.inverse)
+            case .seventh:
+                self.init(ordered.inverse)
+            }
+        }
+    }
+}
+
+extension UnorderedIntervalDescriptor.Ordinal {
+
+    // MARK: - Nested Types
+
+    /// Perfect ordinals.
+    public enum Perfect {
+
+        // MARK: - Cases
+
+        /// Unison perfect unordered interval ordinal.
+        case unison
+
+        /// Fourth perfect unordered interval ordinal.
+        case fourth
+    }
+
+    /// Imperfect ordinals.
+    public enum Imperfect {
+
+        // MARK: - Cases
+
+        /// Second imperfect unordered interval ordinal.
+        case second
+
+        /// Third imperfect unordered interval ordinal.
+        case third
+    }
+}
+
+extension UnorderedIntervalDescriptor {
+
+    // MARK: - Type Properties
+
+    /// Unison interval.
+    public static var unison: UnorderedIntervalDescriptor {
+        return .init(.perfect, .unison)
+    }
+}
+
+extension UnorderedIntervalDescriptor {
+
+    // MARK: - Initializers
+
+    // MARK: Perfect Interval Descriptors
+
+    /// Creates a perfect `UnorderedIntervalDescriptor`.
+    ///
+    ///     let perfectUnison = UnorderedIntervalDescriptor(.perfect, .unison)
+    ///     let perfectFourth = UnorderedIntervalDescriptor(.perfect, .fourth)
+    ///     let perfectFifth = UnorderedIntervalDescriptor(.perfect, .fifth)
+    ///
+    public init(_ quality: IntervalQuality.Perfect, _ ordinal: Ordinal.Perfect) {
+        self.quality = .perfect(.perfect)
+        self.ordinal = .perfect(ordinal)
+    }
+
+    // MARK: Imperfect Interval Descriptors
+
+    /// Creates an imperfect `UnorderedIntervalDescriptor`.
+    ///
+    ///     let majorSecond = UnorderedIntervalDescriptor(.major, .second)
+    ///     let minorThird = UnorderedIntervalDescriptor(.minor, .third)
+    ///
+    public init(_ quality: IntervalQuality.Imperfect, _ ordinal: Ordinal.Imperfect) {
+        self.quality = .imperfect(quality)
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    // MARK: Augmented or Diminished Interval Descriptors
+
+    /// Creates an augmented or diminished `UnorderedIntervalDescriptor` with an imperfect ordinal.
+    ///
+    ///     let doubleDiminishedSecond = UnorderedIntervalDescriptor(.diminished, .second)
+    ///     let tripleAugmentedThird = UnorderedIntervalDescriptor(.augmented, .third)
+    ///
+    public init(_ quality: IntervalQuality.Extended.AugmentedOrDiminished, _ ordinal: Ordinal.Imperfect) {
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `UnorderedIntervalDescriptor` with a perfect ordinal.
+    ///
+    ///     let doubleAugmentedUnison = UnorderedIntervalDescriptor(.augmented, .unison)
+    ///     let tripleDiminishedFourth = UnorderedIntervalDescriptor(.diminished, .fourth)
+    ///
+    public init(_ quality: IntervalQuality.Extended.AugmentedOrDiminished, _ ordinal: Ordinal.Perfect) {
+        self.quality = .extended(.init(.single, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedSpelledInterval` with a imperfect ordinal. These
+    /// intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleAugmentedUnison = OrderedSpelledInterval(.double, .augmented, .second)
+    ///     let tripleDiminishedFourth = OrderedSpelledInterval(.triple, .diminished, .third)
+    ///
+    public init(
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Imperfect
+        )
+    {
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .imperfect(ordinal)
+    }
+
+    /// Creates an augmented or diminished `OrderedSpelledInterval` with a perfect ordinal. These
+    /// intervals can be up to quintuple augmented or diminished.
+    ///
+    ///     let doubleAugmentedUnison = OrderedSpelledInterval(.double, .augmented, .unison)
+    ///     let tripleDiminishedFourth = OrderedSpelledInterval(.triple, .diminished, .fourth)
+    ///
+    public init(
+        _ degree: IntervalQuality.Extended.Degree,
+        _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
+        _ ordinal: Ordinal.Perfect
+        )
+    {
+        self.quality = .extended(.init(degree, quality))
+        self.ordinal = .perfect(ordinal)
+    }
+
+    /// Creates a `UnorderedIntervalDescriptor` with a given `quality` and `ordinal`.
+    ///
+    ///     let minorSecond = UnorderedIntervalDescriptor(.minor, .second)
+    ///     let augmentedSixth = UnorderedIntervalDescriptor(.augmented, .sixth)
+    ///
+    internal init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
+        self.quality = quality
+        self.ordinal = ordinal
+    }
+}
+
+extension UnorderedIntervalDescriptor.Ordinal: Equatable, Hashable { }
+extension UnorderedIntervalDescriptor: Equatable, Hashable { }
+
+extension UnorderedIntervalDescriptor.Ordinal {
+
+    public var platonicThreshold: Double {
+        switch self {
+        case .perfect:
+            return 1
+        case .imperfect:
+            return 1.5
+        }
+    }
+
+    static func platonicInterval(steps: Int) -> Double {
+        assert((0..<4).contains(steps))
+        switch steps {
+        case 0: // unison
+            return 0
+        case 1: // second
+            return 1.5
+        case 2: // third
+            return 3.5
+        case 3: // fourth
+            return 5
+        default: // impossible
+            fatalError("Impossible")
+        }
+    }
+}

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -146,7 +146,6 @@ extension UnorderedIntervalDescriptor {
     ///
     ///     let perfectUnison = UnorderedIntervalDescriptor(.perfect, .unison)
     ///     let perfectFourth = UnorderedIntervalDescriptor(.perfect, .fourth)
-    ///     let perfectFifth = UnorderedIntervalDescriptor(.perfect, .fifth)
     ///
     public init(_ quality: IntervalQuality.Perfect, _ ordinal: Ordinal.Perfect) {
         self.quality = .perfect(.perfect)
@@ -187,17 +186,17 @@ extension UnorderedIntervalDescriptor {
         self.ordinal = .perfect(ordinal)
     }
 
-    /// Creates an augmented or diminished `OrderedSpelledInterval` with a imperfect ordinal. These
-    /// intervals can be up to quintuple augmented or diminished.
+    /// Creates an augmented or diminished `UnorderedIntervalDescriptor` with an imperfect ordinal.
+    /// These intervals can be up to quintuple augmented or diminished.
     ///
-    ///     let doubleAugmentedUnison = OrderedSpelledInterval(.double, .augmented, .second)
-    ///     let tripleDiminishedFourth = OrderedSpelledInterval(.triple, .diminished, .third)
+    ///     let doubleAugmentedUnison = OrderedSpelledInterval(.double, .augmented, .unison)
+    ///     let tripleDiminishedFourth = OrderedSpelledInterval(.triple, .diminished, .fourth)
     ///
     public init(
         _ degree: IntervalQuality.Extended.Degree,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Imperfect
-        )
+    )
     {
         self.quality = .extended(.init(degree, quality))
         self.ordinal = .imperfect(ordinal)
@@ -213,7 +212,7 @@ extension UnorderedIntervalDescriptor {
         _ degree: IntervalQuality.Extended.Degree,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Perfect
-        )
+    )
     {
         self.quality = .extended(.init(degree, quality))
         self.ordinal = .perfect(ordinal)

--- a/Sources/Pitch/Pitch.swift
+++ b/Sources/Pitch/Pitch.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 James Bean. All rights reserved.
 //
 
+import Algebra
 import Math
 
 /// The quality of a sound governed by the rate of vibrations producing it.
@@ -59,3 +60,12 @@ extension Pitch {
 
 extension Pitch: Equatable { }
 extension Pitch: Hashable { }
+
+extension Pitch: Additive {
+
+    // MARK: - Additive
+
+    public static var zero: Pitch {
+        return 0
+    }
+}

--- a/Sources/Pitch/Scale.swift
+++ b/Sources/Pitch/Scale.swift
@@ -6,6 +6,19 @@
 //
 
 public struct Scale {
+
+    // MARK: - Instance Properties
+
     let first: Pitch
     let intervals: [Pitch]
+}
+
+extension Scale {
+
+    // MARK: - Initializers
+
+    init(_ first: Pitch, _ intervals: [Pitch]) {
+        self.first = first
+        self.intervals = intervals
+    }
 }

--- a/Sources/Pitch/Scale.swift
+++ b/Sources/Pitch/Scale.swift
@@ -1,0 +1,11 @@
+//
+//  Scale.swift
+//  Pitch
+//
+//  Created by James Bean on 10/9/18.
+//
+
+public struct Scale {
+    let first: Pitch
+    let intervals: [Pitch]
+}

--- a/Sources/Pitch/Scale.swift
+++ b/Sources/Pitch/Scale.swift
@@ -10,15 +10,31 @@ public struct Scale {
     // MARK: - Instance Properties
 
     let first: Pitch
-    let intervals: [Pitch]
+    let intervals: IntervalPattern
+}
+
+extension Scale {
+
+    public struct IntervalPattern {
+        let intervals: [Pitch]
+    }
 }
 
 extension Scale {
 
     // MARK: - Initializers
 
-    init(_ first: Pitch, _ intervals: [Pitch]) {
+    init(_ first: Pitch, _ intervals: IntervalPattern) {
         self.first = first
         self.intervals = intervals
+    }
+}
+
+extension Scale.IntervalPattern: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral intervals: Pitch...) {
+        self.init(intervals: intervals)
     }
 }

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -5,6 +5,8 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import DataStructures
+
 extension Scale {
 
     public struct IntervalPattern {
@@ -35,6 +37,12 @@ extension Scale.IntervalPattern: ExpressibleByArrayLiteral {
 
     public init(arrayLiteral intervals: Pitch...) {
         self.init(intervals: intervals)
+    }
+}
+
+extension Scale.IntervalPattern: CollectionWrapping {
+    public var base: [Pitch] {
+        return intervals
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -1,32 +1,14 @@
 //
-//  Scale.swift
+//  Scale.IntervalPattern.swift
 //  Pitch
 //
 //  Created by James Bean on 10/9/18.
 //
 
-public struct Scale {
-
-    // MARK: - Instance Properties
-
-    let first: Pitch
-    let intervals: IntervalPattern
-}
-
 extension Scale {
 
     public struct IntervalPattern {
         let intervals: [Pitch]
-    }
-}
-
-extension Scale {
-
-    // MARK: - Initializers
-
-    init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.first = first
-        self.intervals = intervals
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -13,6 +13,13 @@ extension Scale {
 }
 
 extension Scale.IntervalPattern {
+
+    public init(_ intervals: [Pitch]) {
+        self.init(intervals: intervals)
+    }
+}
+
+extension Scale.IntervalPattern {
     static var major: Scale.IntervalPattern { return [2,2,1,2,2,2,1] }
     static var minor: Scale.IntervalPattern { return [2,1,2,2,1,2,2] }
     static var melodicMinorAscending: Scale.IntervalPattern { return [2,1,2,2,2,2,1] }
@@ -30,3 +37,6 @@ extension Scale.IntervalPattern: ExpressibleByArrayLiteral {
         self.init(intervals: intervals)
     }
 }
+
+extension Scale.IntervalPattern: Equatable { }
+extension Scale.IntervalPattern: Hashable { }

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -12,6 +12,16 @@ extension Scale {
     }
 }
 
+extension Scale.IntervalPattern {
+    static var major: Scale.IntervalPattern { return [2,2,1,2,2,2,1] }
+    static var minor: Scale.IntervalPattern { return [2,1,2,2,1,2,2] }
+    static var melodicMinorAscending: Scale.IntervalPattern { return [2,1,2,2,2,2,1] }
+    static var melodicMinorDescending: Scale.IntervalPattern { return .minor }
+    static var harmonicMinor: Scale.IntervalPattern { return [2,1,2,2,1,3,1] }
+    static var octatonic21: Scale.IntervalPattern { return [2,1,2,1,2,1,2,1] }
+    static var octatonic12: Scale.IntervalPattern { return [1,2,1,2,1,2,1,2] }
+}
+
 extension Scale.IntervalPattern: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -27,6 +27,17 @@ extension Scale.IntervalPattern {
     var span: Pitch {
         return intervals.sum
     }
+
+    var scaleDegrees: [String] {
+        switch self {
+        case .major:
+            return ["I","ii","iii","IV","V","vi","vii"]
+        case .minor:
+            return ["i","ii","III","iv","V","IV","vii"]
+        default:
+            return (0..<intervals.count).map { "\($0 + 1)" }
+        }
+    }
 }
 
 extension Scale.IntervalPattern {

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -5,7 +5,7 @@
 //  Created by James Bean on 10/9/18.
 //
 
-import Algebra
+import DataStructures
 
 public struct Scale {
 
@@ -33,6 +33,17 @@ extension Scale {
         let sorted = sequence.sorted()
         precondition(!sorted.isEmpty, "Cannot create a 'Scale' with an empty sequence of pitches")
         self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
+    }
+}
+
+extension Scale {
+
+    func pitch(scaleDegree: Int) -> Pitch? {
+        return pitches[safe: scaleDegree]
+    }
+
+    func scaleDegree(pitch: Pitch) -> Int? {
+        return pitches.index(of: pitch)
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -5,12 +5,13 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import Algebra
+
 public struct Scale {
 
     // MARK: - Instance Properties
 
-    let first: Pitch
-    let intervals: IntervalPattern
+    let pitches: [Pitch]
 }
 
 extension Scale {
@@ -18,13 +19,19 @@ extension Scale {
     // MARK: - Initializers
 
     init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.first = first
-        self.intervals = intervals
+        // TODO: Make `Pitch` a monoid to allow `accumulatingRight`
+        var p = [first]
+        var accum: Pitch = 0
+        for i in intervals.intervals {
+            accum += i
+            p.append(first + accum)
+        }
+        self.pitches = p
     }
 
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
         let sorted = sequence.sorted()
-        precondition(!sorted.isEmpty, "Cannot create a 'Chord' with an empty sequence of pitches")
+        precondition(!sorted.isEmpty, "Cannot create a 'Scale' with an empty sequence of pitches")
         self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
     }
 }

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -19,10 +19,12 @@ extension Scale {
 
     // MARK: - Initializers
 
+    /// Creates a `Scale` with the given `first` pitch and the given `intervals`.
     init(_ first: Pitch, _ intervals: IntervalPattern) {
         self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
     }
 
+    /// Creates a `Scale` with the pitches in the given `sequence`.
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
         let sorted = sequence.sorted()
         precondition(!sorted.isEmpty, "Cannot create a 'Scale' with an empty sequence of pitches")

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -8,7 +8,6 @@
 import Algebra
 import DataStructures
 
-// TODO: Make (optional) looping sequence
 public struct Scale {
 
     // MARK: - Instance Properties

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -5,6 +5,7 @@
 //  Created by James Bean on 10/9/18.
 //
 
+import Algebra
 import DataStructures
 
 public struct Scale {
@@ -19,14 +20,7 @@ extension Scale {
     // MARK: - Initializers
 
     init(_ first: Pitch, _ intervals: IntervalPattern) {
-        // TODO: Make `Pitch` a monoid to allow `accumulatingRight`
-        var p = [first]
-        var accum: Pitch = 0
-        for i in intervals.intervals {
-            accum += i
-            p.append(first + accum)
-        }
-        self.pitches = p
+        self.pitches = [first] + intervals.intervals.accumulatingSum.map { $0 + first }
     }
 
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -20,7 +20,7 @@ extension Scale {
     // MARK: - Initializers
 
     init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.pitches = [first] + intervals.intervals.accumulatingSum.map { $0 + first }
+        self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
     }
 
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -8,6 +8,7 @@
 import Algebra
 import DataStructures
 
+// TODO: Make (optional) looping sequence
 public struct Scale {
 
     // MARK: - Instance Properties
@@ -35,9 +36,11 @@ extension Scale {
 extension Scale {
 
     func pitch(scaleDegree: Int) -> Pitch? {
-        return pitches[safe: scaleDegree]
+        let index = scaleDegree - 1
+        return pitches[safe: index]
     }
 
+    // FIXME: Currently only works for pitches in first octave. Extend to modulo-12
     func scaleDegree(pitch: Pitch) -> Int? {
         return pitches.index(of: pitch)
     }

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -18,7 +18,7 @@ public struct Scale {
 
 extension Scale {
     var isOctaveRepeating: Bool {
-        return intervals.span == 12
+        return intervals.span == 12 && intervals.isLooping
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -1,0 +1,24 @@
+//
+//  Scale.swift
+//  Pitch
+//
+//  Created by James Bean on 10/9/18.
+//
+
+public struct Scale {
+
+    // MARK: - Instance Properties
+
+    let first: Pitch
+    let intervals: IntervalPattern
+}
+
+extension Scale {
+
+    // MARK: - Initializers
+
+    init(_ first: Pitch, _ intervals: IntervalPattern) {
+        self.first = first
+        self.intervals = intervals
+    }
+}

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -35,8 +35,10 @@ extension Scale {
     /// Creates a `Scale` with the pitches in the given `sequence`.
     init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
         let sorted = sequence.sorted()
-        precondition(!sorted.isEmpty, "Cannot create a 'Scale' with an empty sequence of pitches")
-        self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
+        guard let first = sorted.first else {
+            fatalError("Cannot create a 'Scale' with an empty sequence of pitches")
+        }
+        self.init(first, IntervalPattern(sorted.pairs.map { $1 - $0 }))
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -21,4 +21,22 @@ extension Scale {
         self.first = first
         self.intervals = intervals
     }
+
+    init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
+        let sorted = sequence.sorted()
+        precondition(!sorted.isEmpty, "Cannot create a 'Chord' with an empty sequence of pitches")
+        self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
+    }
 }
+
+extension Scale: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral pitches: Pitch...) {
+        self.init(pitches)
+    }
+}
+
+extension Scale: Equatable { }
+extension Scale: Hashable { }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,16 +1,16 @@
 import XCTest
 
 import ArticulationsTests
+import PitchTests
 import DurationTests
 import DynamicsTests
-import PitchTests
 import MusicModelTests
 
 var tests = [XCTestCaseEntry]()
 tests += ArticulationsTests.__allTests()
+tests += PitchTests.__allTests()
 tests += DurationTests.__allTests()
 tests += DynamicsTests.__allTests()
-tests += PitchTests.__allTests()
 tests += MusicModelTests.__allTests()
 
 XCTMain(tests)

--- a/Tests/MusicModelTests/XCTestManifests.swift
+++ b/Tests/MusicModelTests/XCTestManifests.swift
@@ -29,6 +29,7 @@ extension ModelTests {
     static let __allTests = [
         ("testAddMeter", testAddMeter),
         ("testAddTempo", testAddTempo),
+        ("testFilterPerformanceContext", testFilterPerformanceContext),
         ("testHelloWorld", testHelloWorld),
         ("testInferOffset", testInferOffset),
         ("testManyRhythms", testManyRhythms),
@@ -40,6 +41,11 @@ extension ModelTests {
 extension PerformanceContextTests {
     static let __allTests = [
         ("testAddVoice", testAddVoice),
+        ("testBuilder", testBuilder),
+        ("testFilterInstruments", testFilterInstruments),
+        ("testFilterPerformers", testFilterPerformers),
+        ("testFilterPerformersAndVoices", testFilterPerformersAndVoices),
+        ("testFilterVoices", testFilterVoices),
         ("testInitEmpty", testInitEmpty),
     ]
 }

--- a/Tests/PitchTests/ChordTests.swift
+++ b/Tests/PitchTests/ChordTests.swift
@@ -1,0 +1,16 @@
+//
+//  ChordTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 10/9/18.
+//
+
+import XCTest
+@testable import Pitch
+
+class ChordTests: XCTestCase {
+
+    func testInitAPI() {
+        let _ = Chord(60, [4,3])
+    }
+}

--- a/Tests/PitchTests/ChordTests.swift
+++ b/Tests/PitchTests/ChordTests.swift
@@ -11,7 +11,9 @@ import XCTest
 class ChordTests: XCTestCase {
 
     func testInitAPI() {
-        let _ = Chord(60, [4,3])
+        let initWithFirstAndIntervals = Chord(60, [4,3])
+        let initWithPitches: Chord = [60,64,67]
+        XCTAssertEqual(initWithFirstAndIntervals, initWithPitches)
     }
 
     func testIntervalPattern() {

--- a/Tests/PitchTests/ChordTests.swift
+++ b/Tests/PitchTests/ChordTests.swift
@@ -13,4 +13,8 @@ class ChordTests: XCTestCase {
     func testInitAPI() {
         let _ = Chord(60, [4,3])
     }
+
+    func testIntervalPattern() {
+        let _: Chord.IntervalPattern = [4,3]
+    }
 }

--- a/Tests/PitchTests/ChordTests.swift
+++ b/Tests/PitchTests/ChordTests.swift
@@ -17,4 +17,12 @@ class ChordTests: XCTestCase {
     func testIntervalPattern() {
         let _: Chord.IntervalPattern = [4,3]
     }
+
+    func testCMajor() {
+        let _ = Chord(60, .major)
+    }
+
+    func testFSharpMinor() {
+        let _ = Chord(66, .minor)
+    }
 }

--- a/Tests/PitchTests/IntervalQualityTests.swift
+++ b/Tests/PitchTests/IntervalQualityTests.swift
@@ -1,0 +1,31 @@
+//
+//  IntervalQualityTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import XCTest
+import Pitch
+
+class IntervalQualityTests: XCTestCase {
+
+    func testInverseDimAug() {
+        let dim = IntervalQuality.extended(.init(.single, .diminished))
+        let aug = IntervalQuality.extended(.init(.single, .augmented))
+        XCTAssertEqual(dim.inverse, aug)
+        XCTAssertEqual(aug.inverse, dim)
+    }
+
+    func testInverseMinorMajor() {
+        let maj = IntervalQuality.imperfect(.major)
+        let min = IntervalQuality.imperfect(.minor)
+        XCTAssertEqual(maj.inverse, min)
+        XCTAssertEqual(min.inverse, maj)
+    }
+
+    func testInversePerfect() {
+        let perfect = IntervalQuality.perfect(.perfect)
+        XCTAssertEqual(perfect.inverse, perfect)
+    }
+}

--- a/Tests/PitchTests/OrderedIntervalDescriptorTests.swift
+++ b/Tests/PitchTests/OrderedIntervalDescriptorTests.swift
@@ -1,0 +1,83 @@
+//
+//  OrderedIntervalDescriptorTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 10/10/18.
+//
+
+import XCTest
+import Pitch
+
+class OrderedIntervalDescriptorTests: XCTestCase {
+
+    typealias Ordinal = OrderedIntervalDescriptor.Ordinal
+
+    func testSecondOrdinalInverseSeventh() {
+        XCTAssertEqual(Ordinal.imperfect(.second).inverse, Ordinal.imperfect(.seventh))
+    }
+
+    func testAPI() {
+        let _: OrderedIntervalDescriptor = .unison
+        let _: OrderedIntervalDescriptor = .init(.minor, .second)
+        let _: OrderedIntervalDescriptor = .init(.perfect, .fifth)
+        let _: OrderedIntervalDescriptor = .init(.perfect, .fourth)
+        let _: OrderedIntervalDescriptor = .init(.augmented, .fifth)
+        let _: OrderedIntervalDescriptor = .init(.diminished, .fifth)
+        let _: OrderedIntervalDescriptor = .init(.augmented, .third)
+        let _: OrderedIntervalDescriptor = .init(.minor, .seventh)
+        let _: OrderedIntervalDescriptor = .init(.triple, .augmented, .seventh)
+        let _: OrderedIntervalDescriptor = .init(.double, .diminished, .fifth)
+    }
+
+    func testAPIShouldNotCompile() {
+        //let _: OrderedIntervalDescriptor = .init(.minor, .fifth)
+        //let _: OrderedIntervalDescriptor = .init(.perfect, .second)
+    }
+
+    func testInversionPerfectFifthPerfectFourth() {
+        let P5 = OrderedIntervalDescriptor(.perfect, .fifth)
+        let P4 = OrderedIntervalDescriptor(.descending, .perfect, .fourth)
+        XCTAssertEqual(P5.inverse, P4)
+        XCTAssertEqual(P4.inverse, P5)
+    }
+
+    func testInversionMajorSecondMinorSeventh() {
+        let M2 = OrderedIntervalDescriptor(.major, .second)
+        let m7 = OrderedIntervalDescriptor(.descending, .minor, .seventh)
+        XCTAssertEqual(M2.inverse, m7)
+        XCTAssertEqual(m7.inverse, M2)
+    }
+
+    func testInversionMajorThirdMinorSixth() {
+        let M3 = OrderedIntervalDescriptor(.descending, .major, .third)
+        let m6 = OrderedIntervalDescriptor(.ascending, .minor, .sixth)
+        XCTAssertEqual(M3.inverse, m6)
+        XCTAssertEqual(m6.inverse, M3)
+    }
+
+    func testAbsoluteNamedIntervalOrdinalInversion() {
+        let sixth = OrderedIntervalDescriptor.Ordinal.imperfect(.sixth)
+        let expected = OrderedIntervalDescriptor.Ordinal.imperfect(.third)
+        XCTAssertEqual(sixth.inverse, expected)
+    }
+
+    func testDoubleAugmentedThirdDoubleDiminishedSixth() {
+        let AA3 = OrderedIntervalDescriptor(.ascending, .double, .augmented, .third)
+        let dd6 = OrderedIntervalDescriptor(.descending, .double, .diminished, .sixth)
+        XCTAssertEqual(AA3.inverse, dd6)
+        XCTAssertEqual(dd6.inverse, AA3)
+    }
+
+    func testPerfectOrdinalUnisonInverse() {
+        let unison = OrderedIntervalDescriptor.Ordinal.perfect(.unison)
+        let expected = OrderedIntervalDescriptor.Ordinal.perfect(.unison)
+        XCTAssertEqual(unison.inverse, expected)
+    }
+
+    func testPerfectOrdinalFourthFifthInverse() {
+        let fourth = OrderedIntervalDescriptor.Ordinal.perfect(.fourth)
+        let fifth = OrderedIntervalDescriptor.Ordinal.perfect(.fifth)
+        XCTAssertEqual(fourth.inverse, fifth)
+        XCTAssertEqual(fifth.inverse, fourth)
+    }
+}

--- a/Tests/PitchTests/PitchTests.swift
+++ b/Tests/PitchTests/PitchTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Algebra
 @testable import Pitch
 
 class PitchTests: XCTestCase {
@@ -38,5 +39,12 @@ class PitchTests: XCTestCase {
         let pitch = Pitch(10.0)
         let sum = 60.0 - pitch
         XCTAssertEqual(sum, 50.0)
+    }
+
+    func testPitchAdditiveMonoid() {
+        let intervals: [Pitch] = [2,1,2,2,1,2]
+        let distances = intervals.accumulatingSum
+        let expected: [Pitch] = [0,2,3,5,7,8]
+        XCTAssertEqual(expected, distances)
     }
 }

--- a/Tests/PitchTests/ScaleTests.swift
+++ b/Tests/PitchTests/ScaleTests.swift
@@ -13,4 +13,13 @@ class ScaleTests: XCTestCase {
     func testInitAPI() {
         let _ = Scale(60, [2,1,2,1,2,1,2,1])
     }
+
+    func testMajor() {
+        let _ = Scale(60, .major)
+    }
+
+    func testMelodicMinor() {
+        let _ = Scale(66, .melodicMinorAscending)
+        let _ = Scale(66, .melodicMinorDescending)
+    }
 }

--- a/Tests/PitchTests/ScaleTests.swift
+++ b/Tests/PitchTests/ScaleTests.swift
@@ -24,4 +24,38 @@ class ScaleTests: XCTestCase {
         let _ = Scale(66, .melodicMinorAscending)
         let _ = Scale(66, .melodicMinorDescending)
     }
+
+    func testScaleDegreeNil() {
+        let cMajor = Scale(60, .major)
+        let pitches: [Pitch] = [61,63,66,68,70]
+        for pitch in pitches {
+            XCTAssertNil(cMajor.scaleDegree(pitch: pitch))
+        }
+    }
+
+    func testScaleDegreeNotNil() {
+        let cMajor = Scale(60, .major)
+        let pitches: [Pitch] = [60,62,64,65,67,69,71]
+        for pitch in pitches {
+            XCTAssertNotNil(cMajor.scaleDegree(pitch: pitch))
+        }
+    }
+
+    func testScaleDegree() {
+        let cMinor = Scale(60, .minor)
+        XCTAssertEqual(cMinor.scaleDegree(pitch: 63), 3)
+    }
+
+    func testPitchFromScaleDegreeNotNil() {
+        let cMinor = Scale(60, .minor)
+        let scaleDegrees = [1,2,3,4,5,6,7]
+        for scaleDegree in scaleDegrees {
+            XCTAssertNotNil(cMinor.pitch(scaleDegree: scaleDegree))
+        }
+    }
+
+    func testPitchFromScaleDegree() {
+        let eMajor = Scale(64, .major)
+        XCTAssertEqual(eMajor.pitch(scaleDegree: 4), 68)
+    }
 }

--- a/Tests/PitchTests/ScaleTests.swift
+++ b/Tests/PitchTests/ScaleTests.swift
@@ -1,0 +1,16 @@
+//
+//  ScaleTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 10/9/18.
+//
+
+import XCTest
+@testable import Pitch
+
+class ScaleTests: XCTestCase {
+
+    func testInitAPI() {
+        let _ = Scale(60, [2,1,2,1,2,1,2,1])
+    }
+}

--- a/Tests/PitchTests/ScaleTests.swift
+++ b/Tests/PitchTests/ScaleTests.swift
@@ -11,7 +11,9 @@ import XCTest
 class ScaleTests: XCTestCase {
 
     func testInitAPI() {
-        let _ = Scale(60, [2,1,2,1,2,1,2,1])
+        let initWithFirstAndIntervals = Scale(60, [2,1,2,1,2,1,2,1])
+        let initWithPitches: Scale = [60,62,63,65,66,68,69,71,72]
+        XCTAssertEqual(initWithFirstAndIntervals, initWithPitches)
     }
 
     func testMajor() {

--- a/Tests/PitchTests/XCTestManifests.swift
+++ b/Tests/PitchTests/XCTestManifests.swift
@@ -1,5 +1,11 @@
 import XCTest
 
+extension ChordTests {
+    static let __allTests = [
+        ("testInitAPI", testInitAPI),
+    ]
+}
+
 extension FrequencyTests {
     static let __allTests = [
         ("testInitIntLiteral", testInitIntLiteral),
@@ -90,9 +96,16 @@ extension PitchTests {
     ]
 }
 
+extension ScaleTests {
+    static let __allTests = [
+        ("testInitAPI", testInitAPI),
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(ChordTests.__allTests),
         testCase(FrequencyTests.__allTests),
         testCase(NoteNumberTests.__allTests),
         testCase(PitchClassDyadTests.__allTests),
@@ -104,6 +117,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(PitchSegmentTests.__allTests),
         testCase(PitchSetTests.__allTests),
         testCase(PitchTests.__allTests),
+        testCase(ScaleTests.__allTests),
     ]
 }
 #endif

--- a/Tests/PitchTests/XCTestManifests.swift
+++ b/Tests/PitchTests/XCTestManifests.swift
@@ -15,9 +15,32 @@ extension FrequencyTests {
     ]
 }
 
+extension IntervalQualityTests {
+    static let __allTests = [
+        ("testInverseDimAug", testInverseDimAug),
+        ("testInverseMinorMajor", testInverseMinorMajor),
+        ("testInversePerfect", testInversePerfect),
+    ]
+}
+
 extension NoteNumberTests {
     static let __allTests = [
         ("testNoteNumberInit", testNoteNumberInit),
+    ]
+}
+
+extension OrderedIntervalDescriptorTests {
+    static let __allTests = [
+        ("testAbsoluteNamedIntervalOrdinalInversion", testAbsoluteNamedIntervalOrdinalInversion),
+        ("testAPI", testAPI),
+        ("testAPIShouldNotCompile", testAPIShouldNotCompile),
+        ("testDoubleAugmentedThirdDoubleDiminishedSixth", testDoubleAugmentedThirdDoubleDiminishedSixth),
+        ("testInversionMajorSecondMinorSeventh", testInversionMajorSecondMinorSeventh),
+        ("testInversionMajorThirdMinorSixth", testInversionMajorThirdMinorSixth),
+        ("testInversionPerfectFifthPerfectFourth", testInversionPerfectFifthPerfectFourth),
+        ("testPerfectOrdinalFourthFifthInverse", testPerfectOrdinalFourthFifthInverse),
+        ("testPerfectOrdinalUnisonInverse", testPerfectOrdinalUnisonInverse),
+        ("testSecondOrdinalInverseSeventh", testSecondOrdinalInverseSeventh),
     ]
 }
 
@@ -94,6 +117,7 @@ extension PitchTests {
         ("testFloatMinusPitch", testFloatMinusPitch),
         ("testFloatPlusPitch", testFloatPlusPitch),
         ("testInit", testInit),
+        ("testPitchAdditiveMonoid", testPitchAdditiveMonoid),
         ("testPitchMinusFloat", testPitchMinusFloat),
         ("testPitchPlusFloat", testPitchPlusFloat),
     ]
@@ -104,6 +128,14 @@ extension ScaleTests {
         ("testInitAPI", testInitAPI),
         ("testMajor", testMajor),
         ("testMelodicMinor", testMelodicMinor),
+        ("testPitchFromScaleDegree0", testPitchFromScaleDegree0),
+        ("testPitchFromScaleDegree3", testPitchFromScaleDegree3),
+        ("testPitchFromScaleDegree9", testPitchFromScaleDegree9),
+        ("testPitchFromScaleDegreeNotNil", testPitchFromScaleDegreeNotNil),
+        ("testScaleDegree", testScaleDegree),
+        ("testScaleDegreeNil", testScaleDegreeNil),
+        ("testScaleDegreeNotNil", testScaleDegreeNotNil),
+        ("testScaleSequenceLooping", testScaleSequenceLooping),
     ]
 }
 
@@ -112,7 +144,9 @@ public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(ChordTests.__allTests),
         testCase(FrequencyTests.__allTests),
+        testCase(IntervalQualityTests.__allTests),
         testCase(NoteNumberTests.__allTests),
+        testCase(OrderedIntervalDescriptorTests.__allTests),
         testCase(PitchClassDyadTests.__allTests),
         testCase(PitchClassIntervalTests.__allTests),
         testCase(PitchClassSetTests.__allTests),

--- a/Tests/PitchTests/XCTestManifests.swift
+++ b/Tests/PitchTests/XCTestManifests.swift
@@ -2,7 +2,10 @@ import XCTest
 
 extension ChordTests {
     static let __allTests = [
+        ("testCMajor", testCMajor),
+        ("testFSharpMinor", testFSharpMinor),
         ("testInitAPI", testInitAPI),
+        ("testIntervalPattern", testIntervalPattern),
     ]
 }
 
@@ -99,6 +102,8 @@ extension PitchTests {
 extension ScaleTests {
     static let __allTests = [
         ("testInitAPI", testInitAPI),
+        ("testMajor", testMajor),
+        ("testMelodicMinor", testMelodicMinor),
     ]
 }
 


### PR DESCRIPTION
This PR adds the following structures:

- `Chord`
- `Chord.IntervalPattern`
- `Scale`
- `Scale.IntervalPattern`

Addresses #85 & #86.

This PR also migrates and renames `IntervalDescriptor`, `IntervalQuality`, `IntervalOrdinal` from the `dn-m/NotationModel/SpelledPitch` universe. These aspects actually did not require knowledge of notational concepts like sharps, flats, etc, but are useful for reasoning about scales and chords.