### PR TITLE
Implement Scale as potentially infinitely looping Sequence

### DIFF
--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -20,8 +20,8 @@ extension Chord {
     // MARK: - Initializers
 
     /// Creates a `Chord` with the given `first` pitch and the given `intervals`.
-    init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
+    init(_ lowest: Pitch, _ intervals: IntervalPattern) {
+        self.pitches = [lowest] + intervals.accumulatingSum.map { $0 + lowest }
     }
 
     /// Creates a `Chord` with the pitches in the given `sequence`.

--- a/Sources/Pitch/Scale/Scale.IntervalPattern.swift
+++ b/Sources/Pitch/Scale/Scale.IntervalPattern.swift
@@ -11,17 +11,26 @@ extension Scale {
 
     public struct IntervalPattern {
         let intervals: [Pitch]
+        let isLooping: Bool
     }
 }
 
 extension Scale.IntervalPattern {
 
-    public init(_ intervals: [Pitch]) {
-        self.init(intervals: intervals)
+    public init(_ intervals: [Pitch], isLooping: Bool = true) {
+        self.init(intervals: intervals, isLooping: isLooping)
     }
 }
 
 extension Scale.IntervalPattern {
+
+    var span: Pitch {
+        return intervals.sum
+    }
+}
+
+extension Scale.IntervalPattern {
+    static var chromatic: Scale.IntervalPattern { return [1,1,1,1,1,1,1,1,1,1,1,1] }
     static var major: Scale.IntervalPattern { return [2,2,1,2,2,2,1] }
     static var minor: Scale.IntervalPattern { return [2,1,2,2,1,2,2] }
     static var melodicMinorAscending: Scale.IntervalPattern { return [2,1,2,2,2,2,1] }
@@ -31,18 +40,37 @@ extension Scale.IntervalPattern {
     static var octatonic12: Scale.IntervalPattern { return [1,2,1,2,1,2,1,2] }
 }
 
+extension Scale.IntervalPattern: Sequence {
+
+    // MARK: - Sequence
+
+    public subscript(index: Int) -> Pitch? {
+        if intervals.indices.contains(index) || isLooping {
+            return intervals[index % intervals.count]
+        } else {
+            return nil
+        }
+    }
+
+    public func makeIterator() -> AnyIterator<Pitch> {
+        var index = 0
+        return AnyIterator {
+            if self.intervals.indices.contains(index) || self.isLooping {
+                defer { index += 1 }
+                return self.intervals[index % self.intervals.count]
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
 extension Scale.IntervalPattern: ExpressibleByArrayLiteral {
 
     // MARK: - ExpressibleByArrayLiteral
 
     public init(arrayLiteral intervals: Pitch...) {
-        self.init(intervals: intervals)
-    }
-}
-
-extension Scale.IntervalPattern: CollectionWrapping {
-    public var base: [Pitch] {
-        return intervals
+        self.init(intervals: intervals, isLooping: true)
     }
 }
 

--- a/Sources/Pitch/Scale/Scale.swift
+++ b/Sources/Pitch/Scale/Scale.swift
@@ -13,7 +13,14 @@ public struct Scale {
 
     // MARK: - Instance Properties
 
-    let pitches: [Pitch]
+    let root: Pitch
+    let intervals: IntervalPattern
+}
+
+extension Scale {
+    var isOctaveRepeating: Bool {
+        return intervals.span == 12
+    }
 }
 
 extension Scale {
@@ -21,8 +28,9 @@ extension Scale {
     // MARK: - Initializers
 
     /// Creates a `Scale` with the given `first` pitch and the given `intervals`.
-    init(_ first: Pitch, _ intervals: IntervalPattern) {
-        self.pitches = [first] + intervals.accumulatingSum.map { $0 + first }
+    init(_ root: Pitch, _ intervals: IntervalPattern) {
+        self.root = root
+        self.intervals = intervals
     }
 
     /// Creates a `Scale` with the pitches in the given `sequence`.
@@ -35,14 +43,47 @@ extension Scale {
 
 extension Scale {
 
+    /// - Returns: The `Pitch` at the given `scaleDegree`, if it exists. Otherwsie, `nil`.
+    ///
+    /// - Note: The scale degree `1` corresponds to the `root` pitch.
+    ///
+    /// - TODO: Build out `ScaleDegree` to a fully-fledged type.
     func pitch(scaleDegree: Int) -> Pitch? {
-        let index = scaleDegree - 1
-        return pitches[safe: index]
+        let target = scaleDegree - 1
+        for (index,pitch) in enumerated() {
+            if !intervals.isLooping && pitch > intervals.span + root { return nil }
+            if target == index { return pitch }
+        }
+        return nil
     }
 
-    // FIXME: Currently only works for pitches in first octave. Extend to modulo-12
-    func scaleDegree(pitch: Pitch) -> Int? {
-        return pitches.index(of: pitch)
+    /// - Returns: The scale degree for the given `pitch`, if it exists. Otherwise, `nil`.
+    ///
+    /// - Note: The scale degree `1` corresponds to the `root` pitch.
+    ///
+    /// - TODO: Build out `ScaleDegree` to a fully-fledged type.
+    func scaleDegree(pitch target: Pitch) -> Int? {
+        for (index,pitch) in enumerated() {
+            if !intervals.isLooping || pitch > intervals.span + root { return nil }
+            if pitch == target { return index + 1 }
+        }
+        return nil
+    }
+}
+
+extension Scale: Sequence {
+
+    // MARK: - Sequence
+
+    public func makeIterator() -> AnyIterator<Pitch> {
+        var index = 0
+        var accum: Pitch = 0
+        return AnyIterator {
+            defer { index += 1 }
+            guard let interval = self.intervals[index] else { return nil }
+            defer { accum += interval }
+            return self.root + accum
+        }
     }
 }
 

--- a/Tests/PitchTests/ScaleTests.swift
+++ b/Tests/PitchTests/ScaleTests.swift
@@ -54,8 +54,25 @@ class ScaleTests: XCTestCase {
         }
     }
 
-    func testPitchFromScaleDegree() {
+    func testPitchFromScaleDegree0() {
         let eMajor = Scale(64, .major)
-        XCTAssertEqual(eMajor.pitch(scaleDegree: 4), 68)
+        XCTAssertEqual(eMajor.pitch(scaleDegree: 1), 64)
+    }
+
+    func testPitchFromScaleDegree3() {
+        let eMajor = Scale(64, .major)
+        XCTAssertEqual(eMajor.pitch(scaleDegree: 3), 68)
+    }
+
+    func testPitchFromScaleDegree9() {
+        let eMajor = Scale(64, .major)
+        XCTAssertEqual(eMajor.pitch(scaleDegree: 9), 78)
+    }
+
+    func testScaleSequenceLooping() {
+        let root: Pitch = 0
+        let intervals = Scale.IntervalPattern(intervals: [2,2,1,2,2,2,1], isLooping: true)
+        let scale = Scale(root,intervals)
+        let _ = Array(scale.prefix(100))
     }
 }


### PR DESCRIPTION
This PR implements `Scale` not as a fixed-size `Collection`, but rather as a potentially infinitely looping `Sequence`.

If a scale `isLooping`, the scale cycles up infinitely during iteration. Otherwise, it is constrained by the original given array of intervals.