### PR TITLE
Expose IntervalDescriptor

### DIFF
--- a/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
@@ -18,4 +18,3 @@ public protocol IntervalDescriptor {
     /// Creates a `IntervalDescriptor` with the given `quality` and the given `ordinal`.
     init(_ quality: IntervalQuality, _ ordinal: Ordinal)
 }
-

--- a/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
@@ -18,3 +18,4 @@ public protocol IntervalDescriptor {
     /// Creates a `IntervalDescriptor` with the given `quality` and the given `ordinal`.
     init(_ quality: IntervalQuality, _ ordinal: Ordinal)
 }
+

--- a/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalDescriptor.swift
@@ -6,7 +6,7 @@
 //
 
 /// Interface for intervals between two `Pitch` values.
-protocol IntervalDescriptor {
+public protocol IntervalDescriptor {
 
     // MARK: - Associated Types
 
@@ -17,65 +17,4 @@ protocol IntervalDescriptor {
 
     /// Creates a `IntervalDescriptor` with the given `quality` and the given `ordinal`.
     init(_ quality: IntervalQuality, _ ordinal: Ordinal)
-}
-
-extension IntervalDescriptor {
-
-    /// Createss a `IntervalDescriptor`-conforming type with the given `interval` (i.e., the distance
-    /// between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values) and the given
-    /// `steps` (i.e., the distance between the `LetterName` attributes of `Pitch.Spelling`
-    /// values).
-    init(interval: Double, steps: Int) {
-        let (quality,ordinal) = Self.qualityAndOrdinal(interval: interval, steps: steps)
-        self.init(quality,ordinal)
-    }
-
-    /// - Returns the `IntervalQuality` and `Ordinal` values for the given `interval` (i.e.,
-    /// the distance between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values)
-    /// and the given `steps (i.e., the distance between the `LetterName` attributes of
-    ///`Pitch.Spelling`  values).
-    static func qualityAndOrdinal(interval: Double, steps: Int)
-        -> (IntervalQuality, Ordinal)
-    {
-        let distance = Ordinal.platonicDistance(from: interval, to: steps)
-        let ordinal = Ordinal(steps: steps)!
-        let quality = IntervalQuality(distance: distance, with: ordinal.platonicThreshold)
-        return (quality, ordinal)
-    }
-}
-
-extension IntervalQuality {
-    init(distance: Double, with platonicThreshold: Double) {
-        let (diminished, augmented) = (-platonicThreshold,platonicThreshold)
-        switch distance {
-        case diminished - 4:
-            self =  .extended(.init(.quintuple, .diminished))
-        case diminished - 3:
-            self = .extended(.init(.quadruple, .diminished))
-        case diminished - 2:
-            self = .extended(.init(.triple, .diminished))
-        case diminished - 1:
-            self = .extended(.init(.double, .diminished))
-        case diminished:
-            self = .extended(.init(.single, .diminished))
-        case -0.5:
-            self = .imperfect(.minor)
-        case +0.0:
-            self = .perfect(.perfect)
-        case +0.5:
-            self = .imperfect(.major)
-        case augmented:
-            self = .extended(.init(.single, .augmented))
-        case augmented + 1:
-            self = .extended(.init(.double, .augmented))
-        case augmented + 2:
-            self = .extended(.init(.triple, .augmented))
-        case augmented + 3:
-            self = .extended(.init(.quadruple, .augmented))
-        case augmented + 4:
-            self = .extended(.init(.quintuple, .augmented))
-        default:
-            fatalError("Not possible to create a NamedIntervalQuality with interval \(distance)")
-        }
-    }
 }

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -8,7 +8,7 @@
 import Math
 
 /// Interface for `IntervalOrdinal`-like values.
-protocol IntervalOrdinal {
+public protocol IntervalOrdinal {
 
     // MARK: - Type Properties
 
@@ -35,7 +35,7 @@ extension IntervalOrdinal {
     /// - Returns: The distance of the given `interval` to the `platonicInterval` from the given
     /// `steps`.
     static func platonicDistance(from interval: Double, to steps: Int) -> Double {
-        let ideal = Self.platonicInterval(steps: steps)
+        let ideal = platonicInterval(steps: steps)
         let difference = interval - ideal
         let normalized = mod(difference + 6, 12) - 6
         return steps == 0 ? abs(normalized) : normalized

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -28,16 +28,3 @@ public protocol IntervalOrdinal {
     init?(steps: Int)
 }
 
-extension IntervalOrdinal {
-
-    // MARK: - Type Methods
-
-    /// - Returns: The distance of the given `interval` to the `platonicInterval` from the given
-    /// `steps`.
-    static func platonicDistance(from interval: Double, to steps: Int) -> Double {
-        let ideal = platonicInterval(steps: steps)
-        let difference = interval - ideal
-        let normalized = mod(difference + 6, 12) - 6
-        return steps == 0 ? abs(normalized) : normalized
-    }
-}

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -10,21 +10,8 @@ import Math
 /// Interface for `IntervalOrdinal`-like values.
 public protocol IntervalOrdinal {
 
-    // MARK: - Type Properties
-
-    /// The distance between the given `steps` and the platonic ideal for this
-    /// `IntervalOrdinal` value.
-    static func platonicInterval(steps: Int) -> Double
-
-    // MARK: - Instance Properties
-
-    /// The distance from the platonic ideal interval where the interval quality becomes diminished
-    /// or augmented.
-    var platonicThreshold: Double { get }
-
     // MARK: - Initializers
 
     /// Creates a `IntervalOrdinal` with the given amount of `steps`.
     init?(steps: Int)
 }
-

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -23,6 +23,13 @@ public struct OrderedIntervalDescriptor: IntervalDescriptor {
     /// IntervalQuality value of a `OrderedIntervalDescriptor`.
     /// (`diminished`, `minor`, `perfect`, `major`, `augmented`).
     public let quality: IntervalQuality
+
+    /// Creates an `OrderedIntervalDescriptor` with the given `direction`, `ordinal`, and `quality`.
+    public init(direction: Direction, ordinal: Ordinal, quality: IntervalQuality) {
+        self.direction = direction
+        self.ordinal = ordinal
+        self.quality = quality
+    }
 }
 
 extension OrderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -27,6 +27,23 @@ public struct OrderedIntervalDescriptor: IntervalDescriptor {
 
 extension OrderedIntervalDescriptor {
 
+    // MARK: - Initializers
+
+    /// Creates an `OrderedIntervalDescriptor` with the given `direction`, `ordinal`, and `quality`.
+    public init(
+        _ direction: Direction = .ascending,
+        _ ordinal: Ordinal,
+        _ quality: IntervalQuality
+    )
+    {
+        self.direction = direction
+        self.ordinal = ordinal
+        self.quality = quality
+    }
+}
+
+extension OrderedIntervalDescriptor {
+
     // MARK: - Nested Types
 
     /// Direction of a `OrderedIntervalDescriptor`.
@@ -144,7 +161,9 @@ extension OrderedIntervalDescriptor.Ordinal {
 }
 
 extension OrderedIntervalDescriptor.Ordinal {
-    var platonicThreshold: Double {
+
+    #warning("Break out to own protocol")
+    public var platonicThreshold: Double {
         switch self {
         case .perfect:
             return 1
@@ -153,25 +172,18 @@ extension OrderedIntervalDescriptor.Ordinal {
         }
     }
 
-    static func platonicInterval(steps: Int) -> Double {
+    #warning("Break out to own protocol")
+    public static func platonicInterval(steps: Int) -> Double {
         assert((0..<7).contains(steps))
         switch steps {
-        case 0:
-            return 0
-        case 1:
-            return 1.5
-        case 2:
-            return 3.5
-        case 3:
-            return 5
-        case 4:
-            return 7
-        case 5:
-            return 8.5
-        case 6:
-            return 10.5
-        default:
-            fatalError("Impossible")
+        case 0: return 0
+        case 1: return 1.5
+        case 2: return 3.5
+        case 3: return 5
+        case 4: return 7
+        case 5: return 8.5
+        case 6: return 10.5
+        default: fatalError("Impossible")
         }
     }
 }
@@ -199,7 +211,7 @@ extension OrderedIntervalDescriptor {
     }
 
     /// Creates an `OrderedIntervalDescriptor` with a given `quality` and `ordinal`.
-    internal init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
+    public init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
         self.direction = .ascending
         self.quality = quality
         self.ordinal = ordinal

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -160,35 +160,6 @@ extension OrderedIntervalDescriptor.Ordinal {
     }
 }
 
-extension OrderedIntervalDescriptor.Ordinal {
-
-    #warning("Break out to own protocol")
-    public var platonicThreshold: Double {
-        switch self {
-        case .perfect:
-            return 1
-        case .imperfect:
-            return 1.5
-        }
-    }
-
-    #warning("Break out to own protocol")
-    public static func platonicInterval(steps: Int) -> Double {
-        assert((0..<7).contains(steps))
-        switch steps {
-        case 0: return 0
-        case 1: return 1.5
-        case 2: return 3.5
-        case 3: return 5
-        case 4: return 7
-        case 5: return 8.5
-        case 6: return 10.5
-        default: fatalError("Impossible")
-        }
-    }
-}
-
-
 extension OrderedIntervalDescriptor {
 
     // MARK: - Type Properties
@@ -261,7 +232,7 @@ extension OrderedIntervalDescriptor {
         _ direction: Direction,
         _ quality: IntervalQuality.Imperfect,
         _ ordinal: Ordinal.Imperfect
-        )
+    )
     {
         self.direction = direction
         self.quality = .imperfect(quality)
@@ -278,7 +249,7 @@ extension OrderedIntervalDescriptor {
         _ degree: IntervalQuality.Extended.Degree,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Imperfect
-        )
+    )
     {
         self.direction = .ascending
         self.quality = .extended(.init(degree, quality))
@@ -296,7 +267,7 @@ extension OrderedIntervalDescriptor {
         _ degree: IntervalQuality.Extended.Degree,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Imperfect
-        )
+    )
     {
         self.direction = direction
         self.quality = .extended(.init(degree, quality))
@@ -313,7 +284,7 @@ extension OrderedIntervalDescriptor {
         _ degree: IntervalQuality.Extended.Degree,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Perfect
-        )
+    )
     {
         self.direction = .ascending
         self.quality = .extended(.init(degree, quality))
@@ -359,7 +330,7 @@ extension OrderedIntervalDescriptor {
         _ direction: Direction,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Imperfect
-        )
+    )
     {
         self.direction = direction
         self.quality = .extended(.init(.single, quality))
@@ -387,7 +358,7 @@ extension OrderedIntervalDescriptor {
         _ direction: Direction,
         _ quality: IntervalQuality.Extended.AugmentedOrDiminished,
         _ ordinal: Ordinal.Perfect
-        )
+    )
     {
         self.direction = direction
         self.quality = .extended(.init(.single, quality))

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -23,13 +23,6 @@ public struct OrderedIntervalDescriptor: IntervalDescriptor {
     /// IntervalQuality value of a `OrderedIntervalDescriptor`.
     /// (`diminished`, `minor`, `perfect`, `major`, `augmented`).
     public let quality: IntervalQuality
-
-    /// Creates an `OrderedIntervalDescriptor` with the given `direction`, `ordinal`, and `quality`.
-    public init(direction: Direction, ordinal: Ordinal, quality: IntervalQuality) {
-        self.direction = direction
-        self.ordinal = ordinal
-        self.quality = quality
-    }
 }
 
 extension OrderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -231,33 +231,3 @@ extension UnorderedIntervalDescriptor {
 
 extension UnorderedIntervalDescriptor.Ordinal: Equatable, Hashable { }
 extension UnorderedIntervalDescriptor: Equatable, Hashable { }
-
-extension UnorderedIntervalDescriptor.Ordinal {
-
-    #warning("Break out into own protocol, perhaps in NotationModel")
-    public var platonicThreshold: Double {
-        switch self {
-        case .perfect:
-            return 1
-        case .imperfect:
-            return 1.5
-        }
-    }
-
-    #warning("Break out into own protocol, perhaps in NotationModel")
-    public static func platonicInterval(steps: Int) -> Double {
-        assert((0..<4).contains(steps))
-        switch steps {
-        case 0: // unison
-            return 0
-        case 1: // second
-            return 1.5
-        case 2: // third
-            return 3.5
-        case 3: // fourth
-            return 5
-        default: // impossible
-            fatalError("Impossible")
-        }
-    }
-}

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -223,7 +223,7 @@ extension UnorderedIntervalDescriptor {
     ///     let minorSecond = UnorderedIntervalDescriptor(.minor, .second)
     ///     let augmentedSixth = UnorderedIntervalDescriptor(.augmented, .sixth)
     ///
-    internal init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
+    public init(_ quality: IntervalQuality, _ ordinal: Ordinal) {
         self.quality = quality
         self.ordinal = ordinal
     }
@@ -234,6 +234,7 @@ extension UnorderedIntervalDescriptor: Equatable, Hashable { }
 
 extension UnorderedIntervalDescriptor.Ordinal {
 
+    #warning("Break out into own protocol, perhaps in NotationModel")
     public var platonicThreshold: Double {
         switch self {
         case .perfect:
@@ -243,7 +244,8 @@ extension UnorderedIntervalDescriptor.Ordinal {
         }
     }
 
-    static func platonicInterval(steps: Int) -> Double {
+    #warning("Break out into own protocol, perhaps in NotationModel")
+    public static func platonicInterval(steps: Int) -> Double {
         assert((0..<4).contains(steps))
         switch steps {
         case 0: // unison


### PR DESCRIPTION
This PR completes the pushing down of the `IntervalDescriptor` (formerly known as `SpelledInterval`) universe from `dn-m/NotationModel/SpelledPitch`.

It slims down the `IntervalDescriptor` protocol to its essential bits, leaving the `SpelledPitch`-converting bits for an additional protocol up in `NotationModel`.