### PR TITLE
Make IntervalQuality associated values Doubles

### DIFF
--- a/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
@@ -28,7 +28,7 @@ extension IntervalQuality {
     // MARK: - Nested Types
 
     /// A perfect interval quality.
-    public enum Perfect: Double {
+    public enum Perfect: Int {
 
         // MARK: - Cases
 
@@ -37,15 +37,15 @@ extension IntervalQuality {
     }
 
     /// An imperfect interval quality.
-    public enum Imperfect: Double, InvertibleEnum {
+    public enum Imperfect: Int, InvertibleEnum {
 
         // MARK: - Cases
 
         /// Major interval quality.
-        case major = 0.5
+        case major = 1
 
         /// Minor interval quality.
-        case minor = -0.5
+        case minor = -1
     }
 
     /// An augmented or diminished interval quality
@@ -55,8 +55,8 @@ extension IntervalQuality {
 
         /// - Returns: The amount of adjustment in semitones from the ideal interval represented by
         /// this `IntervalQuality.Extended`.
-        public var adjustment: Double {
-            return Double(degree.rawValue) * quality.rawValue
+        public var adjustment: Int {
+            return degree.rawValue * quality.rawValue
         }
 
         /// - Returns: Inversion of `self`.
@@ -65,11 +65,11 @@ extension IntervalQuality {
         }
 
         /// Whether this `Extended` quality is augmented or diminished
-        let quality: AugmentedOrDiminished
+        public let quality: AugmentedOrDiminished
 
         /// The degree to which this quality is augmented or diminished (e.g., double augmented,
         /// etc.)
-        let degree: Degree
+        public let degree: Degree
 
         // MARK: Initializers
 
@@ -86,7 +86,7 @@ extension IntervalQuality.Extended {
     // MARK: - Nested Types
 
     /// Either augmented or diminished
-    public enum AugmentedOrDiminished: Double, InvertibleEnum {
+    public enum AugmentedOrDiminished: Int, InvertibleEnum {
 
         // MARK: - Cases
 
@@ -135,7 +135,7 @@ extension IntervalQuality {
 
     /// - Returns: The amount of adjustment in semitones from the ideal interval represented by this
     /// `IntervalQuality`.
-    public var adjustment: Double {
+    public var adjustment: Int {
         switch self {
         case .perfect(let perfect):
             return perfect.rawValue

--- a/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
@@ -28,7 +28,7 @@ extension IntervalQuality {
     // MARK: - Nested Types
 
     /// A perfect interval quality.
-    public enum Perfect: Int {
+    public enum Perfect: Double {
 
         // MARK: - Cases
 
@@ -37,15 +37,15 @@ extension IntervalQuality {
     }
 
     /// An imperfect interval quality.
-    public enum Imperfect: Int, InvertibleEnum {
+    public enum Imperfect: Double, InvertibleEnum {
 
         // MARK: - Cases
 
         /// Major interval quality.
-        case major = 1
+        case major = 0.5
 
         /// Minor interval quality.
-        case minor = -1
+        case minor = -0.5
     }
 
     /// An augmented or diminished interval quality
@@ -55,8 +55,8 @@ extension IntervalQuality {
 
         /// - Returns: The amount of adjustment in semitones from the ideal interval represented by
         /// this `IntervalQuality.Extended`.
-        public var adjustment: Int {
-            return degree.rawValue * quality.rawValue
+        public var adjustment: Double {
+            return Double(degree.rawValue) * quality.rawValue
         }
 
         /// - Returns: Inversion of `self`.
@@ -86,7 +86,7 @@ extension IntervalQuality.Extended {
     // MARK: - Nested Types
 
     /// Either augmented or diminished
-    public enum AugmentedOrDiminished: Int, InvertibleEnum {
+    public enum AugmentedOrDiminished: Double, InvertibleEnum {
 
         // MARK: - Cases
 
@@ -135,7 +135,7 @@ extension IntervalQuality {
 
     /// - Returns: The amount of adjustment in semitones from the ideal interval represented by this
     /// `IntervalQuality`.
-    public var adjustment: Int {
+    public var adjustment: Double {
         switch self {
         case .perfect(let perfect):
             return perfect.rawValue

--- a/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalQuality.swift
@@ -28,30 +28,36 @@ extension IntervalQuality {
     // MARK: - Nested Types
 
     /// A perfect interval quality.
-    public enum Perfect {
+    public enum Perfect: Double {
 
         // MARK: - Cases
 
         /// Perfect interval quality.
-        case perfect
+        case perfect = 0
     }
 
     /// An imperfect interval quality.
-    public enum Imperfect: InvertibleEnum {
+    public enum Imperfect: Double, InvertibleEnum {
 
         // MARK: - Cases
 
         /// Major interval quality.
-        case major
+        case major = 0.5
 
         /// Minor interval quality.
-        case minor
+        case minor = -0.5
     }
 
     /// An augmented or diminished interval quality
     public struct Extended: Invertible {
 
         // MARK: Instance Properties
+
+        /// - Returns: The amount of adjustment in semitones from the ideal interval represented by
+        /// this `IntervalQuality.Extended`.
+        public var adjustment: Double {
+            return Double(degree.rawValue) * quality.rawValue
+        }
 
         /// - Returns: Inversion of `self`.
         public var inverse: Extended {
@@ -80,15 +86,15 @@ extension IntervalQuality.Extended {
     // MARK: - Nested Types
 
     /// Either augmented or diminished
-    public enum AugmentedOrDiminished: InvertibleEnum {
+    public enum AugmentedOrDiminished: Double, InvertibleEnum {
 
         // MARK: - Cases
 
         /// Augmented extended interval quality.
-        case augmented
+        case augmented = 1
 
         /// Diminished extended interval quality.
-        case diminished
+        case diminished = -1
     }
 
     /// The degree to which an `Extended` quality is augmented or diminished.
@@ -124,6 +130,19 @@ extension IntervalQuality {
             return .imperfect(quality.inverse)
         case .extended(let quality):
             return .extended(quality.inverse)
+        }
+    }
+
+    /// - Returns: The amount of adjustment in semitones from the ideal interval represented by this
+    /// `IntervalQuality`.
+    public var adjustment: Double {
+        switch self {
+        case .perfect(let perfect):
+            return perfect.rawValue
+        case .imperfect(let imperfect):
+            return imperfect.rawValue
+        case .extended(let extended):
+            return extended.adjustment
         }
     }
 }


### PR DESCRIPTION
These associated values represent adjustments in semitones from the ideal semitone interval of a given `IntervalDescriptor`.