### PR TITLE
Add static convenience helpers for IntervalDescriptor types

### DIFF
--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -40,6 +40,50 @@ extension CompoundIntervalDescriptor {
 
     /// Unison.
     public static let unison = CompoundIntervalDescriptor(.unison)
+
+    /// Minor second.
+    public static let m2 = CompoundIntervalDescriptor(.m2)
+
+    /// Major second.
+    public static let M2 = CompoundIntervalDescriptor(.M2)
+
+    /// Minor third.
+    public static let m3 = CompoundIntervalDescriptor(.m3)
+
+    /// Major third.
+    public static let M3 = CompoundIntervalDescriptor(.M3)
+
+    /// Diminished fourth.
+    public static let d4 = CompoundIntervalDescriptor(.d4)
+
+    /// Perfect fourth.
+    public static let P4 = CompoundIntervalDescriptor(.P4)
+
+    /// Augmented fourth.
+    public static let A4 = CompoundIntervalDescriptor(.A4)
+
+    /// Diminished fifth
+    public static let d5 = CompoundIntervalDescriptor(.d5)
+
+    /// Augmented fifth.
+    public static let A5 = CompoundIntervalDescriptor(.A5)
+
+    /// Minor sixth.
+    public static let m6 = CompoundIntervalDescriptor(.m6)
+
+    /// Major sixth.
+    public static let M6 = CompoundIntervalDescriptor(.M6)
+
+    /// Minor seventh.
+    public static let m7 = CompoundIntervalDescriptor(.m7)
+
+    /// Major seventh.
+    public static let M7 = CompoundIntervalDescriptor(.M7)
+
+    /// Octave.
+    public static let octave = CompoundIntervalDescriptor(.unison, displacedBy: 1)
+
+    // TODO: Add intervals spanning more than one octave
 }
 
 extension CompoundIntervalDescriptor: Equatable { }

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -38,10 +38,8 @@ extension CompoundIntervalDescriptor {
 
 extension CompoundIntervalDescriptor {
 
-    /// - Returns: Unison compound interval descriptor.
-    public static var unison: CompoundIntervalDescriptor {
-        return .init(.unison)
-    }
+    /// Unison.
+    public static let unison = CompoundIntervalDescriptor(.unison)
 }
 
 extension CompoundIntervalDescriptor: Equatable { }

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -176,6 +176,45 @@ extension OrderedIntervalDescriptor {
 
     /// - Returns: Unison ordered interval descriptor.
     public static let unison = OrderedIntervalDescriptor(.perfect, .unison)
+
+    /// Minor second.
+    public static let m2 = OrderedIntervalDescriptor(.minor, .second)
+
+    /// Major second.
+    public static let M2 = OrderedIntervalDescriptor(.major, .second)
+
+    /// Minor third.
+    public static let m3 = OrderedIntervalDescriptor(.minor, .third)
+
+    /// Major third.
+    public static let M3 = OrderedIntervalDescriptor(.major, .third)
+
+    /// Diminished fourth.
+    public static let d4 = OrderedIntervalDescriptor(.diminished, .fourth)
+
+    /// Perfect fourth.
+    public static let P4 = OrderedIntervalDescriptor(.perfect, .fourth)
+
+    /// Augmented fourth.
+    public static let A4 = OrderedIntervalDescriptor(.augmented, .fourth)
+
+    /// Diminished fifth
+    public static let d5 = OrderedIntervalDescriptor(.diminished, .fifth)
+
+    /// Augmented fifth.
+    public static let A5 = OrderedIntervalDescriptor(.augmented, .fifth)
+
+    /// Minor sixth.
+    public static let m6 = OrderedIntervalDescriptor(.minor, .sixth)
+
+    /// Major sixth.
+    public static let M6 = OrderedIntervalDescriptor(.major, .sixth)
+
+    /// Minor seventh.
+    public static let m7 = OrderedIntervalDescriptor(.minor, .seventh)
+
+    /// Major seventh.
+    public static let M7 = OrderedIntervalDescriptor(.major, .seventh)
 }
 
 extension OrderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -175,9 +175,7 @@ extension OrderedIntervalDescriptor {
     // MARK: - Type Properties
 
     /// - Returns: Unison ordered interval descriptor.
-    public static var unison: OrderedIntervalDescriptor {
-        return .init(.perfect, .unison)
-    }
+    public static let unison = OrderedIntervalDescriptor(.perfect, .unison)
 }
 
 extension OrderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -174,7 +174,7 @@ extension OrderedIntervalDescriptor {
 
     // MARK: - Type Properties
 
-    /// - Returns: Unison ordered interval descriptor.
+    /// Unison.
     public static let unison = OrderedIntervalDescriptor(.perfect, .unison)
 
     /// Minor second.

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -215,6 +215,8 @@ extension OrderedIntervalDescriptor {
 
     /// Major seventh.
     public static let M7 = OrderedIntervalDescriptor(.major, .seventh)
+
+    // TODO: Add diminished / augmented imperfect intervals
 }
 
 extension OrderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -163,6 +163,8 @@ extension UnorderedIntervalDescriptor {
 
     /// Augmented fourth.
     public static let A4 = UnorderedIntervalDescriptor(.augmented, .fourth)
+
+    // TODO: Add diminished / augmented imperfect intervals
 }
 
 extension UnorderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -141,9 +141,7 @@ extension UnorderedIntervalDescriptor {
     // MARK: - Type Properties
 
     /// Unison interval.
-    public static var unison: UnorderedIntervalDescriptor {
-        return .init(.perfect, .unison)
-    }
+    public static let unison = UnorderedIntervalDescriptor(.perfect, .unison)
 }
 
 extension UnorderedIntervalDescriptor {

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -140,7 +140,7 @@ extension UnorderedIntervalDescriptor {
 
     // MARK: - Type Properties
 
-    /// Unison interval.
+    /// Unison.
     public static let unison = UnorderedIntervalDescriptor(.perfect, .unison)
 
     /// Minor second.

--- a/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/UnorderedIntervalDescriptor.swift
@@ -142,6 +142,27 @@ extension UnorderedIntervalDescriptor {
 
     /// Unison interval.
     public static let unison = UnorderedIntervalDescriptor(.perfect, .unison)
+
+    /// Minor second.
+    public static let m2 = UnorderedIntervalDescriptor(.minor, .second)
+
+    /// Major second.
+    public static let M2 = UnorderedIntervalDescriptor(.major, .second)
+
+    /// Minor third.
+    public static let m3 = UnorderedIntervalDescriptor(.minor, .third)
+
+    /// Major third.
+    public static let M3 = UnorderedIntervalDescriptor(.major, .third)
+
+    /// Diminished fourth.
+    public static let d4 = UnorderedIntervalDescriptor(.diminished, .fourth)
+
+    /// Perfect fourth.
+    public static let P4 = UnorderedIntervalDescriptor(.perfect, .fourth)
+
+    /// Augmented fourth.
+    public static let A4 = UnorderedIntervalDescriptor(.augmented, .fourth)
 }
 
 extension UnorderedIntervalDescriptor {


### PR DESCRIPTION
This PR adds shorthand for `UnorderedIntervalDescriptor`, `OrderedIntervalDescriptor`, and `CompoundIntervalDescriptor` types.

These will compose nicely when we need things like:

```Swift
let intervals: [CompoundIntervalDescriptor] = [.m2, .A4, .m2, .d3, .P5]
```

As well as:

```Swift
let eFlat = .middleC + .m3
```