### PR TITLE
Initial implementation of ChordDescriptor

### DIFF
--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -1,0 +1,33 @@
+//
+//  ChordDescriptor.swift
+//  Pitch
+//
+//  Created by James Bean on 10/23/18.
+//
+
+import DataStructures
+
+public struct ChordDescriptor {
+    let intervals: [CompoundIntervalDescriptor]
+}
+
+extension ChordDescriptor: RandomAccessCollectionWrapping {
+
+    // MARK: - RandomAccessCollectionWrapping
+
+    /// - Returns: The `RandomAccessCollection` base of a `ChordDescriptor`.
+    public var base: [CompoundIntervalDescriptor] {
+        return intervals
+    }
+}
+
+extension ChordDescriptor: ExpressibleByArrayLiteral {
+
+    // MARK: ExpressibleByArrayLiteral
+
+    /// Creates a `ChordDescriptor` with the given array literal of `CompoundIntervalDescriptor`
+    /// values.
+    public init(arrayLiteral intervals: CompoundIntervalDescriptor...) {
+        self.intervals = intervals
+    }
+}

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -7,7 +7,20 @@
 
 import DataStructures
 
+/// Description of a simultaneity of pitches wherein the intervals between the pitches are
+/// described.
+///
+/// **Example Usage**
+///
+///     let minor: ChordDescriptor = [.M3, .m3]
+///     let major: ChordDescriptor = [.m3, .M3]
+///     let diminished: ChordDescriptor = [.m3, .m3]
+///     let augmented: ChordDescriptor = [.M3, .M3]
+///
 public struct ChordDescriptor {
+
+    // MARK: - Instance Properties
+
     let intervals: [CompoundIntervalDescriptor]
 }
 

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -12,8 +12,8 @@ import DataStructures
 ///
 /// **Example Usage**
 ///
-///     let minor: ChordDescriptor = [.M3, .m3]
-///     let major: ChordDescriptor = [.m3, .M3]
+///     let major: ChordDescriptor = [.M3, .m3]
+///     let minor: ChordDescriptor = [.m3, .M3]
 ///     let diminished: ChordDescriptor = [.m3, .m3]
 ///     let augmented: ChordDescriptor = [.M3, .M3]
 ///

--- a/Tests/PitchTests/ChordDescriptorTests.swift
+++ b/Tests/PitchTests/ChordDescriptorTests.swift
@@ -11,9 +11,9 @@ import Pitch
 class ChordDescriptorTests: XCTestCase {
 
     func testInitAPI() {
-        let _: ChordDescriptor = [.M3, .m3]
-        let _: ChordDescriptor = [.m3, .M3]
-        let _: ChordDescriptor = [.m3, .m3]
-        let _: ChordDescriptor = [.M3, .M3]
+        let _: ChordDescriptor = [.M3, .m3] // major
+        let _: ChordDescriptor = [.m3, .M3] // minor
+        let _: ChordDescriptor = [.m3, .m3] // diminished
+        let _: ChordDescriptor = [.M3, .M3] // augmented
     }
 }

--- a/Tests/PitchTests/ChordDescriptorTests.swift
+++ b/Tests/PitchTests/ChordDescriptorTests.swift
@@ -1,0 +1,19 @@
+//
+//  ChordDescriptorTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 10/23/18.
+//
+
+import XCTest
+import Pitch
+
+class ChordDescriptorTests: XCTestCase {
+
+    func testInitAPI() {
+        let _: ChordDescriptor = [.M3, .m3]
+        let _: ChordDescriptor = [.m3, .M3]
+        let _: ChordDescriptor = [.m3, .m3]
+        let _: ChordDescriptor = [.M3, .M3]
+    }
+}


### PR DESCRIPTION
`ChordDescriptor` adds an API to describe simultaneities of pitches between which intervals have been described (namely, as `CompoundIntervalDescriptor` values).

It is easy to make them:

```Swift
let major: ChordDescriptor = [.M3, .m3]
let minor: ChordDescriptor = [.m3, .M3]
let diminished: ChordDescriptor = [.m3, .m3]
let augmented: ChordDescriptor = [.M3, .M3]
```

This will compose nicely down-the-line for things like `SpelledChord`:

```Swift
// straw man init
let secondaryDominant = SpelledChord(.f, .sharp, .diminished)
```

Closes #105.