### PR TITLE
Improve Pitch / Pitch.Class APIs

### DIFF
--- a/Sources/Pitch/NoteNumber.swift
+++ b/Sources/Pitch/NoteNumber.swift
@@ -63,3 +63,13 @@ extension NoteNumber {
 
 extension NoteNumber: Equatable { }
 extension NoteNumber: Hashable { }
+
+extension NoteNumber: CustomStringConvertible {
+
+    // MARK: - CustomStringConvertible
+
+    /// Printable description of `NoteNumber`.
+    public var description: String {
+        return value.description
+    }
+}

--- a/Sources/Pitch/Pitch.Class.swift
+++ b/Sources/Pitch/Pitch.Class.swift
@@ -51,6 +51,16 @@ extension Pitch {
 extension Pitch.Class: Equatable { }
 extension Pitch.Class: Hashable { }
 
+extension Pitch.Class: CustomStringConvertible {
+
+    // MARK: - CustomStringConvertible
+
+    /// Printable description of `Pitch.Class`.
+    public var description: String {
+        return value.description
+    }
+}
+
 extension Pitch.Class {
 
     // MARK: - Nested Types

--- a/Sources/Pitch/Pitch.Class.swift
+++ b/Sources/Pitch/Pitch.Class.swift
@@ -29,7 +29,7 @@ extension Pitch {
         ///     let light = dark.inversion // => 8
         ///
         public var inversion: Pitch.Class {
-            return Pitch.Class(NoteNumber(12) - value)
+            return Pitch.Class(12 - value)
         }
 
         /// Value of `Pitch.Class`.

--- a/Sources/Pitch/Pitch.h
+++ b/Sources/Pitch/Pitch.h
@@ -1,7 +1,0 @@
-//
-//  Pitch.h
-//  Pitch
-//
-//  Created by James Bean on 3/12/16.
-//  Copyright © 2016 James Bean. All rights reserved.
-//

--- a/Sources/Pitch/Pitch.swift
+++ b/Sources/Pitch/Pitch.swift
@@ -37,7 +37,17 @@ public struct Pitch: NoteNumberRepresentable {
 
 extension Pitch {
 
-    // MARK: Computed Properties
+    // MARK: - Initializers
+
+    /// Creates a `Pitch` with the given `Pitch.Class`.
+    public init(_ pitchClass: Pitch.Class) {
+        self.init(pitchClass.value)
+    }
+}
+
+extension Pitch {
+
+    // MARK: - Computed Properties
 
     /// - Returns: The `mod 12` representation of this `Pitch`.
     public var `class`: Pitch.Class {

--- a/Sources/Pitch/Pitch.swift
+++ b/Sources/Pitch/Pitch.swift
@@ -79,3 +79,13 @@ extension Pitch: Additive {
         return 0
     }
 }
+
+extension Pitch: CustomStringConvertible {
+
+    // MARK: - CustomStringConvertible
+
+    /// Printable description of `Pitch`.
+    public var description: String {
+        return value.description
+    }
+}


### PR DESCRIPTION
This PR adds `Pitch.init(_: Pitch.Class)`, and adds `CustomStringConvertible` to the `Pitch`-ecosystem types.