### PR TITLE
[Meter] Fix bug where numerator / denominator of sum of meters would recurse

### DIFF
--- a/Sources/Duration/Meter/Meter.Kind.swift
+++ b/Sources/Duration/Meter/Meter.Kind.swift
@@ -95,7 +95,7 @@ extension Meter.Kind: Rational {
         case .fractional(let fraction, let subdivision):
             return (Fraction(1,subdivision) * fraction).numerator
         case .additive(let meters):
-            return meters.sum.numerator
+            return meters.map(Fraction.init).sum.numerator
         }
     }
 
@@ -107,7 +107,7 @@ extension Meter.Kind: Rational {
         case .fractional(let fraction, let subdivision):
             return (Fraction(1,subdivision) * fraction).denominator
         case .additive(let meters):
-            return meters.sum.denominator
+            return meters.map(Fraction.init).sum.denominator
         }
     }
 }

--- a/Tests/DurationTests/MeterTests.swift
+++ b/Tests/DurationTests/MeterTests.swift
@@ -61,4 +61,10 @@ class MeterTests: XCTestCase {
         ].map(Fraction.init)
         XCTAssertEqual(result, expected)
     }
+
+    func testMetersSum() {
+        let meters = [(1,4),(2,4),(3,4),(5,4)].map(Meter.init)
+        let _ = meters.sum.numerator
+        let _ = meters.sum.denominator
+    }
 }

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -70,6 +70,7 @@ extension MeterTests {
         ("testBeatOffsetsFractional", testBeatOffsetsFractional),
         ("testFractionalMeter", testFractionalMeter),
         ("testIrrationalMeter", testIrrationalMeter),
+        ("testMetersSum", testMetersSum),
         ("testNormalMeter", testNormalMeter),
     ]
 }

--- a/Tests/PitchTests/XCTestManifests.swift
+++ b/Tests/PitchTests/XCTestManifests.swift
@@ -1,5 +1,11 @@
 import XCTest
 
+extension ChordDescriptorTests {
+    static let __allTests = [
+        ("testInitAPI", testInitAPI),
+    ]
+}
+
 extension ChordTests {
     static let __allTests = [
         ("testCMajor", testCMajor),
@@ -142,6 +148,7 @@ extension ScaleTests {
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
+        testCase(ChordDescriptorTests.__allTests),
         testCase(ChordTests.__allTests),
         testCase(FrequencyTests.__allTests),
         testCase(IntervalQualityTests.__allTests),


### PR DESCRIPTION
This PR fixes a bug in `Meter` preventing infinite recursion when calling `numerator` or `denominator` on a `sum` of meters.

This is because the `Additive` sum of a `Meter` is an `Meter.Kind.additive`.