### PR TITLE
Implement fast path for Meter.Kind addition when both elements are .single

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ let fractional = Meter(Fraction(3,5),16)
 Ordinary and fractional meters can be concatenated into a single additive meter.
 
 ```Swift
-let blueRondo = Meter(2,8) + Meter(2,8) + Meter(2,8) + Meter(3,8)
+let blueRondo = Meter(Meter(2,8), Meter(2,8),Meter(2,8),Meter(3,8))
 let czernowinSQm5 = Meter(Meter(1,4),Meter(3,16))
 let czernowinSQm7 = Meter(Meter(1,4),Meter(Fraction(2,3),4))
 ```

--- a/Sources/Duration/Meter/Meter.Kind.swift
+++ b/Sources/Duration/Meter/Meter.Kind.swift
@@ -45,7 +45,13 @@ extension Meter.Kind: Additive {
 
     /// The additive operation.
     static func + (_ lhs: Meter.Kind, _ rhs: Meter.Kind) -> Meter.Kind {
-        return .additive([lhs,rhs])
+        switch (lhs,rhs) {
+        case let (.single(lhsBeats, lhsSubdivision), .single(rhsBeats, rhsSubdivision)):
+            let fraction = Fraction(lhsBeats, lhsSubdivision) + Fraction(rhsBeats, rhsSubdivision)
+            return .single(fraction.numerator, fraction.denominator)
+        default:
+            return .additive([lhs,rhs])
+        }
     }
 }
 

--- a/Sources/Duration/Meter/Meter.swift
+++ b/Sources/Duration/Meter/Meter.swift
@@ -85,7 +85,7 @@ extension Meter: Additive {
 
     /// - Returns: An additive meter composed of the two given meters.
     public static func + (_ lhs: Meter, _ rhs: Meter) -> Meter {
-        return .init(kinds: [lhs.kind, rhs.kind])
+        return Meter(kind: lhs.kind + rhs.kind)
     }
 }
 

--- a/Tests/DurationTests/MeterTests.swift
+++ b/Tests/DurationTests/MeterTests.swift
@@ -67,4 +67,10 @@ class MeterTests: XCTestCase {
         let _ = meters.sum.numerator
         let _ = meters.sum.denominator
     }
+
+    func testManyMetersSum() {
+        let meters = (0..<1_000).map { _ in Meter(Int.random(in: 1 ..< 8), 4) }
+        let sum: Meter = meters.sum
+        let numerator = sum.numerator
+    }
 }

--- a/Tests/DurationTests/MeterTests.swift
+++ b/Tests/DurationTests/MeterTests.swift
@@ -69,8 +69,8 @@ class MeterTests: XCTestCase {
     }
 
     func testManyMetersSum() {
-        let meters = (0..<1_000).map { _ in Meter(Int.random(in: 1 ..< 8), 4) }
+        let meters = (0..<10_000).map { _ in Meter(Int.random(in: 1 ..< 8), 4) }
         let sum: Meter = meters.sum
-        let numerator = sum.numerator
+        let _ = sum.numerator
     }
 }

--- a/Tests/DurationTests/XCTestManifests.swift
+++ b/Tests/DurationTests/XCTestManifests.swift
@@ -70,6 +70,7 @@ extension MeterTests {
         ("testBeatOffsetsFractional", testBeatOffsetsFractional),
         ("testFractionalMeter", testFractionalMeter),
         ("testIrrationalMeter", testIrrationalMeter),
+        ("testManyMetersSum", testManyMetersSum),
         ("testMetersSum", testMetersSum),
         ("testNormalMeter", testNormalMeter),
     ]


### PR DESCRIPTION
In simple cases of adding `Meter` values, the current implementation creates an `.additive` `Meter.Kind` under the hood, which has to allocate an array each time. This blows up under any but the most trivial conditions.

This PR implements a fast path for `Meter` addition when both values are built on a `.single` `Meter.Kind` value. Thus, the following: 

```Swift
Meter(3,4) + Meter(4,4)
``` 

Returns: 

```Swift
Meter(7,4)
```

not 

```Swift
Meter(kind: .additive([.single(3,4), .single(4,4])))
```

This drastically improves performance for the common case.

Closes #119.