### PR TITLE
Test against multiple Swift 5 versions and use Xcode 11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode10.2
+osx_image: xcode11
 install:
   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 env:
   - SWIFT_VERSION=5.0
+  - SWIFT_VERSION=5.0.1
+  - SWIFT_VERSION=5.1-DEVELOPMENT-SNAPSHOT-2019-08-14-a
 script:
   - swift package update
   - swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Math",
         "repositoryURL": "https://github.com/dn-m/Math",
         "state": {
-          "branch": "swift-5",
-          "revision": "51f8032aa2aea3e8a88b44dcc858c4551b855478",
-          "version": null
+          "branch": null,
+          "revision": "519c7e3128e80fbfd43d7cc0c0947b86d423db8a",
+          "version": "0.8.0"
         }
       },
       {
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/dn-m/PerformanceTesting",
         "state": {
           "branch": null,
-          "revision": "d48417c837b1a029dd9567dfa7b5ee3cfa9a0ec7",
-          "version": "0.3.0"
+          "revision": "7c73a60c4b69b981ac3dd4015cc26cea0e45c8c7",
+          "version": "0.4.0"
         }
       },
       {
         "package": "Structure",
         "repositoryURL": "https://github.com/dn-m/Structure",
         "state": {
-          "branch": "swift-5",
-          "revision": "8f67514cba950f60ee992a8d0996d4f11d9654b0",
-          "version": null
+          "branch": null,
+          "revision": "d2f9eaa00b47888a684c9a91836501fd7ea7e141",
+          "version": "0.24.0"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Music
 
-![Swift Version](https://img.shields.io/badge/Swift-4.2-orange.svg)
+![Swift Version](https://img.shields.io/badge/Swift-5.0-orange.svg)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)
 [![Build Status](https://travis-ci.org/dn-m/Music.svg?branch=master)](https://travis-ci.org/dn-m/Music)
 

--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -53,15 +53,16 @@ extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
     }
 }
 
-extension Chord.IntervalPattern: CollectionWrapping {
-
-    // MARK: - CollectionWrapping
-
-    /// - Returns: The `Collection` base of a `Chord.IntervalPattern`.
-    public var base: [Pitch] {
-        return intervals
-    }
-}
+#warning("FIXME: Reinstate Chord.IntervalPattern: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed.")
+//extension Chord.IntervalPattern: CollectionWrapping {
+//
+//    // MARK: - CollectionWrapping
+//
+//    /// - Returns: The `Collection` base of a `Chord.IntervalPattern`.
+//    public var base: [Pitch] {
+//        return intervals
+//    }
+//}
 
 extension Chord.IntervalPattern: Equatable { }
 extension Chord.IntervalPattern: Hashable { }

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -28,7 +28,8 @@ extension Chord {
 
     /// Creates a `Chord` with the given `first` pitch and the given `intervals`.
     init(_ lowest: Pitch, _ intervals: IntervalPattern) {
-        self.pitches = [lowest] + intervals.accumulatingSum.map { $0 + lowest }
+        // FIXME: Use `intervals.accumulatingSum` when https://bugs.swift.org/browse/SR-11048 if fixed.
+        self.pitches = [lowest] + intervals.intervals.accumulatingSum.map { $0 + lowest }
     }
 
     /// Creates a `Chord` with the pitches in the given `sequence`.
@@ -39,15 +40,16 @@ extension Chord {
     }
 }
 
-extension Chord: RandomAccessCollectionWrapping {
-
-    // MARK: - RandomAccessCollectionWrapping
-
-    /// - Returns: The `RandomAccessCollection` of `Pitch` values contained herein.
-    public var base: [Pitch] {
-        return pitches
-    }
-}
+#warning("FIXME: Reinstate Chord: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed.")
+//extension Chord: RandomAccessCollectionWrapping {
+//
+//    // MARK: - RandomAccessCollectionWrapping
+//
+//    /// - Returns: The `RandomAccessCollection` of `Pitch` values contained herein.
+//    public var base: [Pitch] {
+//        return pitches
+//    }
+//}
 
 extension Chord: ExpressibleByArrayLiteral {
 

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -24,13 +24,92 @@ public struct ChordDescriptor {
     let intervals: [CompoundIntervalDescriptor]
 }
 
-extension ChordDescriptor: RandomAccessCollectionWrapping {
+extension ChordDescriptor/*: RandomAccessCollectionWrapping*/ {
 
     // MARK: - RandomAccessCollectionWrapping
 
     /// - Returns: The `RandomAccessCollection` base of a `ChordDescriptor`.
     public var base: [CompoundIntervalDescriptor] {
         return intervals
+    }
+}
+
+#warning("FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084")
+extension ChordDescriptor: RandomAccessCollection {
+
+    // MARK: - RandomAccessCollection
+
+    public typealias Base = [CompoundIntervalDescriptor]
+
+    /// Start index.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var startIndex: Base.Index {
+        return base.startIndex
+    }
+
+    /// End index.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var endIndex: Base.Index {
+        return base.endIndex
+    }
+
+    /// First element, if there is at least one element. Otherwise, `nil`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var first: Base.Element? {
+        return base.first
+    }
+
+    /// Last element, if there is at least one element. Otherwise, `nil`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var last: Base.Element? {
+        return base.last
+    }
+
+    /// Amount of elements.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var count: Int {
+        return base.count
+    }
+
+    /// - Returns: `true` if there are no elements contained herein. Otherwise, `false`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var isEmpty: Bool {
+        return base.isEmpty
+    }
+
+    /// - Returns: The element at the given `index`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public subscript(position: Base.Index) -> Base.Element {
+        return base[position]
+    }
+
+    /// - Returns: Index after the given `index`.
+    ///
+    /// - Complexity: O(1)
+    public func index(after index: Base.Index) -> Base.Index {
+        return base.index(after: index)
+    }
+
+    /// - Returns: Index before the given `index`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public func index(before index: Base.Index) -> Base.Index {
+        return base.index(before: index)
     }
 }
 

--- a/Sources/Pitch/Pitch.Class.swift
+++ b/Sources/Pitch/Pitch.Class.swift
@@ -81,7 +81,7 @@ extension Pitch.Class {
     ///     let normalForm = pcs.normalForm // => [4,6,8,0]
     ///     let primeForm = pcs.primeForm // => [0,2,4,8]
     ///
-    public struct Collection: RandomAccessCollectionWrapping {
+    public struct Collection {
 
         // MARK: - Instance Properties
 
@@ -189,6 +189,85 @@ extension Pitch.Class {
         public func sorted() -> Collection {
             return sorted(by: <)
         }
+    }
+}
+
+#warning("FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084")
+extension Pitch.Class.Collection: RandomAccessCollection {
+
+    // MARK: - RandomAccessCollection
+
+    public typealias Base = [Pitch.Class]
+
+    /// Start index.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var startIndex: Base.Index {
+        return base.startIndex
+    }
+
+    /// End index.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var endIndex: Base.Index {
+        return base.endIndex
+    }
+
+    /// First element, if there is at least one element. Otherwise, `nil`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var first: Base.Element? {
+        return base.first
+    }
+
+    /// Last element, if there is at least one element. Otherwise, `nil`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var last: Base.Element? {
+        return base.last
+    }
+
+    /// Amount of elements.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var count: Int {
+        return base.count
+    }
+
+    /// - Returns: `true` if there are no elements contained herein. Otherwise, `false`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public var isEmpty: Bool {
+        return base.isEmpty
+    }
+
+    /// - Returns: The element at the given `index`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public subscript(position: Base.Index) -> Base.Element {
+        return base[position]
+    }
+
+    /// - Returns: Index after the given `index`.
+    ///
+    /// - Complexity: O(1)
+    public func index(after index: Base.Index) -> Base.Index {
+        return base.index(after: index)
+    }
+
+    /// - Returns: Index before the given `index`.
+    ///
+    /// - Complexity: O(1)
+    ///
+    public func index(before index: Base.Index) -> Base.Index {
+        return base.index(before: index)
     }
 }
 


### PR DESCRIPTION
This PR expands the amount of Swift compilers used to test this code.

Hopefully sniffing out a way to workaround [this bug](https://bugs.swift.org/browse/SR-11048).