### PR TITLE
Add AdditiveGroup conformance to CompoundIntervalDescriptor

### DIFF
--- a/Sources/Pitch/Chord/Chord.IntervalPattern.swift
+++ b/Sources/Pitch/Chord/Chord.IntervalPattern.swift
@@ -53,7 +53,7 @@ extension Chord.IntervalPattern: ExpressibleByArrayLiteral {
     }
 }
 
-#warning("FIXME: Reinstate Chord.IntervalPattern: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed.")
+// FIXME: Reinstate Chord.IntervalPattern: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed.
 //extension Chord.IntervalPattern: CollectionWrapping {
 //
 //    // MARK: - CollectionWrapping

--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -40,7 +40,7 @@ extension Chord {
     }
 }
 
-#warning("FIXME: Reinstate Chord: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed.")
+// FIXME: Reinstate Chord: CollectionWrapping when https://bugs.swift.org/browse/SR-11048 if fixed."
 //extension Chord: RandomAccessCollectionWrapping {
 //
 //    // MARK: - RandomAccessCollectionWrapping

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -31,6 +31,16 @@ public struct ChordDescriptor {
     }
 }
 
+extension ChordDescriptor {
+
+    // MARK: - Type Properties
+
+    public static let major: ChordDescriptor = [.M3, .m3]
+    public static let minor: ChordDescriptor = [.m3, .M3]
+    public static let diminished: ChordDescriptor = [.m3, .m3]
+    public static let augmented: ChordDescriptor = [.M3, .M3]
+}
+
 extension ChordDescriptor/*: RandomAccessCollectionWrapping*/ {
 
     // MARK: - RandomAccessCollectionWrapping

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -22,6 +22,13 @@ public struct ChordDescriptor {
     // MARK: - Instance Properties
 
     let intervals: [CompoundIntervalDescriptor]
+
+    // MARK: - Initializers
+
+    /// Creates a `ChordDescriptor` with the given `intervals`.
+    public init(_ intervals: [CompoundIntervalDescriptor]) {
+        self.intervals = intervals
+    }
 }
 
 extension ChordDescriptor/*: RandomAccessCollectionWrapping*/ {

--- a/Sources/Pitch/Chord/ChordDescriptor.swift
+++ b/Sources/Pitch/Chord/ChordDescriptor.swift
@@ -34,7 +34,7 @@ extension ChordDescriptor/*: RandomAccessCollectionWrapping*/ {
     }
 }
 
-#warning("FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084")
+// FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084"
 extension ChordDescriptor: RandomAccessCollection {
 
     // MARK: - RandomAccessCollection

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -88,7 +88,7 @@ extension CompoundIntervalDescriptor: AdditiveGroup {
     }
 
     /// Mutates the left-hand-side by subtracting the right-hand-side.
-    public static func -= (lhs: inout Self, rhs: Self) {
+    public static func -= (lhs: inout CompoundIntervalDescriptor, rhs: CompoundIntervalDescriptor) {
         lhs = lhs - rhs
     }
 

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -53,7 +53,8 @@ extension CompoundIntervalDescriptor: AdditiveGroup {
     ///     let minorSeventh = perfectFifth + minorThird // => .m7
     ///
     /// - Returns: The sum of the given `CompoundIntervalDescriptors`.
-    public static func + (lhs: Self, rhs: Self) -> Self {
+    public static func + (lhs: CompoundIntervalDescriptor, rhs: CompoundIntervalDescriptor)
+        -> CompoundIntervalDescriptor {
         let semitones = lhs.interval.semitones + rhs.interval.semitones
         let steps = lhs.interval.ordinal.steps + rhs.interval.ordinal.steps
         let stepsModuloOctave = mod(steps,7)
@@ -63,7 +64,7 @@ extension CompoundIntervalDescriptor: AdditiveGroup {
     }
 
     /// Mutates the left-hand-side by adding the right-hand-side.
-    public static func += (lhs: inout Self, rhs: Self) {
+    public static func += (lhs: inout CompoundIntervalDescriptor, rhs: CompoundIntervalDescriptor) {
         lhs = lhs + rhs
     }
 
@@ -74,7 +75,8 @@ extension CompoundIntervalDescriptor: AdditiveGroup {
     ///     let majorThird = perfectFifth - minorThird // => .M3
     ///
     /// - Returns: The sum of the given `CompoundIntervalDescriptors`.
-    public static func - (lhs: Self, rhs: Self) -> Self {
+    public static func - (lhs: CompoundIntervalDescriptor, rhs: CompoundIntervalDescriptor)
+        -> CompoundIntervalDescriptor {
         let semitones = lhs.interval.semitones - rhs.interval.semitones
         let steps = lhs.interval.ordinal.steps - rhs.interval.ordinal.steps
         let stepsModuloOctave = mod(steps,7)

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -238,7 +238,7 @@ func idealSemitoneInterval(steps: Int) -> Double {
     }
 }
 
-extension IntervalDescriptor {
+extension IntervalDescriptor where Ordinal: WesternScaleMappingOrdinal {
 
     /// Creates a `IntervalDescriptor`-conforming type with the given `interval` (i.e., the distance
     /// between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values) and the given
@@ -261,9 +261,7 @@ extension IntervalDescriptor {
     }
 }
 
-
-
-extension OrderedIntervalDescriptor.Ordinal {
+extension OrderedIntervalDescriptor.Ordinal: WesternScaleMappingOrdinal {
 
     /// - Returns: The distance in semitones from an iedal interval at which point an interval
     /// quality becomes diminished or augmented for a given `Ordinal`.
@@ -277,11 +275,11 @@ extension OrderedIntervalDescriptor.Ordinal {
     }
 }
 
-extension UnorderedIntervalDescriptor.Ordinal {
+extension UnorderedIntervalDescriptor.Ordinal: WesternScaleMappingOrdinal {
 
     /// - Returns: The distance in semitones from an iedal interval at which point an interval
     /// quality becomes diminished or augmented for a given `Ordinal`.
-    public var platonicThreshold: Double {
+    var platonicThreshold: Double {
         switch self {
         case .perfect:
             return 1
@@ -327,7 +325,7 @@ extension OrderedIntervalDescriptor.Ordinal {
 }
 
 extension OrderedIntervalDescriptor {
-    public var semitones: Double {
+    var semitones: Double {
         return ordinal.idealInterval + quality.adjustment
     }
 }

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -5,6 +5,9 @@
 //  Created by James Bean on 10/10/18.
 //
 
+import Algebra
+import Math
+
 /// A descriptor for intervals between two `Pitch` values which takes into account octave
 /// displacement.
 public struct CompoundIntervalDescriptor: IntervalDescriptor {
@@ -36,10 +39,20 @@ extension CompoundIntervalDescriptor {
     }
 }
 
-extension CompoundIntervalDescriptor {
+extension CompoundIntervalDescriptor: AdditiveGroup {
 
     // MARK: - Type Methods
 
+    /// The `unison` is the `zero` for the `CompoundIntervalDescriptor` `AdditiveGroup`.
+    public static let zero: CompoundIntervalDescriptor = .unison
+
+    /// **Example Usage:**
+    ///
+    ///     let perfectFifth: CompoundIntervalDescriptor = .P5
+    ///     let minorThird: CompoundIntervalDescriptor = .m3
+    ///     let minorSeventh = perfectFifth + minorThird // => .m7
+    ///
+    /// - Returns: The sum of the given `CompoundIntervalDescriptors`.
     public static func + (lhs: Self, rhs: Self) -> Self {
         let semitones = lhs.interval.semitones + rhs.interval.semitones
         let steps = lhs.interval.ordinal.steps + rhs.interval.ordinal.steps
@@ -49,10 +62,18 @@ extension CompoundIntervalDescriptor {
         return CompoundIntervalDescriptor(interval, displacedBy: octaves)
     }
 
+    /// Mutates the left-hand-side by adding the right-hand-side.
     public static func += (lhs: inout Self, rhs: Self) {
         lhs = lhs + rhs
     }
 
+    /// **Example Usage:**
+    ///
+    ///     let perfectFifth: CompoundIntervalDescriptor = .P5
+    ///     let minorThird: CompoundIntervalDescriptor = .m3
+    ///     let majorThird = perfectFifth - minorThird // => .M3
+    ///
+    /// - Returns: The sum of the given `CompoundIntervalDescriptors`.
     public static func - (lhs: Self, rhs: Self) -> Self {
         let semitones = lhs.interval.semitones - rhs.interval.semitones
         let steps = lhs.interval.ordinal.steps - rhs.interval.ordinal.steps
@@ -64,8 +85,19 @@ extension CompoundIntervalDescriptor {
         )
     }
 
+    /// Mutates the left-hand-side by subtracting the right-hand-side.
     public static func -= (lhs: inout Self, rhs: Self) {
         lhs = lhs - rhs
+    }
+
+    /// - Returns: The `inverse` of a `CompoundIntervalDescriptor`.
+    public static prefix func - (element: CompoundIntervalDescriptor) -> CompoundIntervalDescriptor {
+        return element.inverse
+    }
+
+    /// - Returns: The `inverse` of a `CompoundIntervalDescriptor`.
+    public var inverse: CompoundIntervalDescriptor {
+        return CompoundIntervalDescriptor(interval.inverse, displacedBy: -octaveDisplacement)
     }
 }
 
@@ -227,7 +259,7 @@ extension IntervalDescriptor {
     }
 }
 
-import Math
+
 
 extension OrderedIntervalDescriptor.Ordinal {
 

--- a/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/CompoundIntervalDescriptor.swift
@@ -38,6 +38,39 @@ extension CompoundIntervalDescriptor {
 
 extension CompoundIntervalDescriptor {
 
+    // MARK: - Type Methods
+
+    public static func + (lhs: Self, rhs: Self) -> Self {
+        let semitones = lhs.interval.semitones + rhs.interval.semitones
+        let steps = lhs.interval.ordinal.steps + rhs.interval.ordinal.steps
+        let stepsModuloOctave = mod(steps,7)
+        let octaves = steps / 7
+        let interval = OrderedIntervalDescriptor(interval: semitones, steps: stepsModuloOctave)
+        return CompoundIntervalDescriptor(interval, displacedBy: octaves)
+    }
+
+    public static func += (lhs: inout Self, rhs: Self) {
+        lhs = lhs + rhs
+    }
+
+    public static func - (lhs: Self, rhs: Self) -> Self {
+        let semitones = lhs.interval.semitones - rhs.interval.semitones
+        let steps = lhs.interval.ordinal.steps - rhs.interval.ordinal.steps
+        let stepsModuloOctave = mod(steps,7)
+        let octaves = steps / 7
+        let interval = OrderedIntervalDescriptor(interval: semitones, steps: stepsModuloOctave)
+        return CompoundIntervalDescriptor(steps >= 0 ? interval : interval.inverse,
+            displacedBy: octaves
+        )
+    }
+
+    public static func -= (lhs: inout Self, rhs: Self) {
+        lhs = lhs - rhs
+    }
+}
+
+extension CompoundIntervalDescriptor {
+
     // MARK: - Type Properties
 
     /// Unison.
@@ -64,8 +97,11 @@ extension CompoundIntervalDescriptor {
     /// Augmented fourth.
     public static let A4 = CompoundIntervalDescriptor(.A4)
 
-    /// Diminished fifth
+    /// Diminished fifth.
     public static let d5 = CompoundIntervalDescriptor(.d5)
+
+    /// Perfect fifth.
+    public static let P5 = CompoundIntervalDescriptor(.P5)
 
     /// Augmented fifth.
     public static let A5 = CompoundIntervalDescriptor(.A5)
@@ -104,3 +140,160 @@ extension CompoundIntervalDescriptor: CustomStringConvertible {
 
 extension CompoundIntervalDescriptor: Equatable { }
 extension CompoundIntervalDescriptor: Hashable { }
+
+extension IntervalQuality {
+    init(distance: Double, with platonicThreshold: Double) {
+        let (diminished, augmented) = (-platonicThreshold,platonicThreshold)
+        switch distance {
+        case diminished - 4:
+            self = .extended(.init(.quintuple, .diminished))
+        case diminished - 3:
+            self = .extended(.init(.quadruple, .diminished))
+        case diminished - 2:
+            self = .extended(.init(.triple, .diminished))
+        case diminished - 1:
+            self = .extended(.init(.double, .diminished))
+        case diminished:
+            self = .extended(.init(.single, .diminished))
+        case -0.5:
+            self = .imperfect(.minor)
+        case +0.0:
+            self = .perfect(.perfect)
+        case +0.5:
+            self = .imperfect(.major)
+        case augmented:
+            self = .extended(.init(.single, .augmented))
+        case augmented + 1:
+            self = .extended(.init(.double, .augmented))
+        case augmented + 2:
+            self = .extended(.init(.triple, .augmented))
+        case augmented + 3:
+            self = .extended(.init(.quadruple, .augmented))
+        case augmented + 4:
+            self = .extended(.init(.quintuple, .augmented))
+        default:
+            fatalError("Not possible to create a NamedIntervalQuality with interval \(distance)")
+        }
+    }
+}
+
+/// - Returns: The "ideal" interval for the given amount of scalar steps between two
+/// `SpelledPitch` values.
+///
+/// For example, perfect intervals have a single ideal spelling, whereas imperfect intervals
+/// could be spelled two different ways.
+func idealSemitoneInterval(steps: Int) -> Double {
+    assert((0..<7).contains(steps))
+    switch steps {
+    case 0:
+        return 0
+    case 1:
+        return 1.5
+    case 2:
+        return 3.5
+    case 3:
+        return 5
+    case 4:
+        return 7
+    case 5:
+        return 8.5
+    case 6:
+        return 10.5
+    default:
+        fatalError("Impossible")
+    }
+}
+
+extension IntervalDescriptor {
+
+    /// Creates a `IntervalDescriptor`-conforming type with the given `interval` (i.e., the distance
+    /// between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values) and the given
+    /// `steps` (i.e., the distance between the `LetterName` attributes of `Pitch.Spelling`
+    /// values).
+    init(interval: Double, steps: Int) {
+        let (quality,ordinal) = Self.qualityAndOrdinal(interval: interval, steps: steps)
+        self.init(quality,ordinal)
+    }
+
+    /// - Returns the `IntervalQuality` and `Ordinal` values for the given `interval` (i.e.,
+    /// the distance between the `NoteNumber` representations of `Pitch` or `Pitch.Class` values)
+    /// and the given `steps (i.e., the distance between the `LetterName` attributes of
+    ///`Pitch.Spelling`  values).
+    static func qualityAndOrdinal(interval: Double, steps: Int) -> (IntervalQuality, Ordinal) {
+        let distance = Ordinal.platonicDistance(from: interval, to: steps)
+        let ordinal = Ordinal(steps: steps)!
+        let quality = IntervalQuality(distance: distance, with: ordinal.platonicThreshold)
+        return (quality, ordinal)
+    }
+}
+
+import Math
+
+extension OrderedIntervalDescriptor.Ordinal {
+
+    /// - Returns: The distance in semitones from an iedal interval at which point an interval
+    /// quality becomes diminished or augmented for a given `Ordinal`.
+    public var platonicThreshold: Double {
+        switch self {
+        case .perfect:
+            return 1
+        case .imperfect:
+            return 1.5
+        }
+    }
+}
+
+extension UnorderedIntervalDescriptor.Ordinal {
+
+    /// - Returns: The distance in semitones from an iedal interval at which point an interval
+    /// quality becomes diminished or augmented for a given `Ordinal`.
+    public var platonicThreshold: Double {
+        switch self {
+        case .perfect:
+            return 1
+        case .imperfect:
+            return 1.5
+        }
+    }
+}
+
+extension IntervalOrdinal {
+
+    /// - Returns: The distance of the given `interval` to the `idealSemitoneInterval` from the given
+    /// `steps`.
+    static func platonicDistance(from interval: Double, to steps: Int) -> Double {
+        let ideal = idealSemitoneInterval(steps: steps)
+        let difference = interval - ideal
+        let normalized = mod(difference + 6, 12) - 6
+        let result = steps == 0 ? abs(normalized) : normalized
+        return result
+    }
+}
+
+extension OrderedIntervalDescriptor.Ordinal {
+
+    // FIXME: Harmonize with `platonic` universe.
+    var idealInterval: Double {
+        switch self {
+        case .perfect(let perfect):
+            switch perfect {
+            case .unison: return 0
+            case .fourth: return 5
+            case .fifth: return 7
+            }
+        case .imperfect(let imperfect):
+            switch imperfect {
+            case .second: return 1.5
+            case .third: return 3.5
+            case .sixth: return 8.5
+            case .seventh: return 10.5
+            }
+        }
+    }
+}
+
+extension OrderedIntervalDescriptor {
+    public var semitones: Double {
+        return ordinal.idealInterval + quality.adjustment
+    }
+}

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -15,6 +15,8 @@ public protocol IntervalOrdinal {
     /// The amount of diatonic steps represented by this `IntervalOrdinal`.
     var steps: Int { get }
 
+    var platonicThreshold: Double { get }
+
     // MARK: - Initializers
 
     /// Creates a `IntervalOrdinal` with the given amount of `steps`.

--- a/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
+++ b/Sources/Pitch/IntervalDescriptor/IntervalOrdinal.swift
@@ -15,10 +15,12 @@ public protocol IntervalOrdinal {
     /// The amount of diatonic steps represented by this `IntervalOrdinal`.
     var steps: Int { get }
 
-    var platonicThreshold: Double { get }
-
     // MARK: - Initializers
 
     /// Creates a `IntervalOrdinal` with the given amount of `steps`.
     init?(steps: Int)
+}
+
+protocol WesternScaleMappingOrdinal: IntervalOrdinal {
+    var platonicThreshold: Double { get }
 }

--- a/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
+++ b/Sources/Pitch/IntervalDescriptor/OrderedIntervalDescriptor.swift
@@ -195,6 +195,9 @@ extension OrderedIntervalDescriptor {
     /// Perfect fourth.
     public static let P4 = OrderedIntervalDescriptor(.perfect, .fourth)
 
+    /// Perfect fifth.
+    public static let P5 = OrderedIntervalDescriptor(.perfect, .fifth)
+
     /// Augmented fourth.
     public static let A4 = OrderedIntervalDescriptor(.augmented, .fourth)
 

--- a/Sources/Pitch/Pitch.Class.swift
+++ b/Sources/Pitch/Pitch.Class.swift
@@ -192,7 +192,7 @@ extension Pitch.Class {
     }
 }
 
-#warning("FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084")
+// FIXME: Reinstate RandomAccessCollectionWrapping conformance SR-11084"
 extension Pitch.Class.Collection: RandomAccessCollection {
 
     // MARK: - RandomAccessCollection

--- a/Tests/PitchTests/CompoundIntervalDescriptorTests.swift
+++ b/Tests/PitchTests/CompoundIntervalDescriptorTests.swift
@@ -1,0 +1,43 @@
+//
+//  CompoundIntervalDescriptorTests.swift
+//  PitchTests
+//
+//  Created by James Bean on 8/24/19.
+//
+
+import XCTest
+import Pitch
+
+class CompoundIntervalDescriptorTests: XCTestCase {
+
+    func testAddLessThanAnOctave() {
+        let result: CompoundIntervalDescriptor = .m2 + .P4
+        let expected: CompoundIntervalDescriptor = .d5
+        XCTAssertEqual(result, expected)
+    }
+
+    func testAddEqualToOctave() {
+        let result: CompoundIntervalDescriptor = .P4 + .P5
+        let expected: CompoundIntervalDescriptor = .octave
+        XCTAssertEqual(result, expected)
+    }
+
+    func testAddMoreThanAnOctave() {
+        let result: CompoundIntervalDescriptor = .P5 + .m6
+        let expected = CompoundIntervalDescriptor(.m3, displacedBy: 1)
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSubtractNoOctaveDisplacement() {
+        let result: CompoundIntervalDescriptor = .M3 - .M2
+        let expected: CompoundIntervalDescriptor = .M2
+        XCTAssertEqual(result, expected)
+    }
+
+    func testSubtractWithOctaveDisplacement() {
+        let result: CompoundIntervalDescriptor = .m3 - .m6
+        let orderedInterval = OrderedIntervalDescriptor(.descending, .perfect, .fourth)
+        let expected: CompoundIntervalDescriptor = CompoundIntervalDescriptor(orderedInterval)
+        XCTAssertEqual(result, expected)
+    }
+}


### PR DESCRIPTION
This PR adds `AdditiveGroup` protocol conformance to `CompoundIntervalDescriptor`.

This means that we can add and subtract 'em. Which means that we can compute intervals in a nice way.