### PR TITLE
Add Chord.init(lowest:descriptor) 

### DIFF
--- a/Sources/Pitch/Chord/Chord.swift
+++ b/Sources/Pitch/Chord/Chord.swift
@@ -27,16 +27,21 @@ extension Chord {
     // MARK: - Initializers
 
     /// Creates a `Chord` with the given `first` pitch and the given `intervals`.
-    init(_ lowest: Pitch, _ intervals: IntervalPattern) {
+    public init(_ lowest: Pitch, _ intervals: IntervalPattern) {
         // FIXME: Use `intervals.accumulatingSum` when https://bugs.swift.org/browse/SR-11048 if fixed.
         self.pitches = [lowest] + intervals.intervals.accumulatingSum.map { $0 + lowest }
     }
 
-    /// Creates a `Chord` with the pitches in the given `sequence`.
-    init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
+    /// Creates a `Chord` with the intervals in the given `sequence`.
+    public init <S> (_ sequence: S) where S: Sequence, S.Element == Pitch {
         let sorted = sequence.sorted()
         precondition(!sorted.isEmpty, "Cannot create a 'Chord' with an empty sequence of pitches")
         self.init(sorted.first!, IntervalPattern(sorted.pairs.map { $1 - $0 }))
+    }
+
+    /// Creates a `Chord` with the given `lowest` pitch and the given `ChordDescriptor`.
+    public init(lowest: Pitch, descriptor: ChordDescriptor) {
+        self.pitches = [lowest] + descriptor.base.map { lowest + Pitch($0.steps) }
     }
 }
 

--- a/Sources/Pitch/NoteNumber.swift
+++ b/Sources/Pitch/NoteNumber.swift
@@ -42,6 +42,11 @@ public struct NoteNumber:
     public init(value: Double) {
         self.value = value
     }
+
+    /// Create a `NoteNumber` with the given `int` value.
+    public init(_ int: Int) {
+        self.value = Double(int)
+    }
 }
 
 extension NoteNumber {

--- a/Sources/Pitch/Pitch.swift
+++ b/Sources/Pitch/Pitch.swift
@@ -33,6 +33,11 @@ public struct Pitch: NoteNumberRepresentable {
     public init(_ value: NoteNumber) {
         self.value = value
     }
+
+    /// Creates a `Pitch` with the given `int` value.
+    public init(_ int: Int) {
+        self.value = NoteNumber(int)
+    }
 }
 
 extension Pitch {


### PR DESCRIPTION
This PR adds a `Chord.init(lowest:descriptor:)` initializer.

Along the way, it adds some `Pitch` and `NoteNumber` initializers for integer values.